### PR TITLE
[#14] Extract jQuery/remove it

### DIFF
--- a/spec/support/helpers/setup.js
+++ b/spec/support/helpers/setup.js
@@ -1,5 +1,8 @@
 import { jsdom } from 'jsdom';
+import jquery from 'jquery';
 
 global.document = jsdom('<html><body></body></html>');
 global.window = global.document.defaultView;
 global.navigator = global.window.navigator;
+
+global.$$$ = jquery(global.window);

--- a/src/common/adapters/github.js
+++ b/src/common/adapters/github.js
@@ -1,19 +1,17 @@
-import $ from 'jquery';
-
-// TODO: remove jquery?
+/* global $$$ */
 
 const trim = (s) => s.replace(/^\s+|\s+$/g, '');
-const has = (sel, ctx) => $(sel, ctx).length > 0;
-const txt = (sel, ctx) => trim($(sel, ctx).text());
-const val = (sel, ctx) => $(sel, ctx).val();
+const has = (sel, ctx) => $$$(sel, ctx).length > 0;
+const txt = (sel, ctx) => trim($$$(sel, ctx).text());
+const val = (sel, ctx) => $$$(sel, ctx).val();
 
 const adapter = {
   inspect(loc, doc, fn) {
     if (has('.issues-listing .js-issue-row.selected', doc)) {
-      const issues = $('.issues-listing .js-issue-row.selected', doc);
+      const issues = $$$('.issues-listing .js-issue-row.selected', doc);
 
       const tickets = issues.map(function extract() {
-        const issue = $(this);
+        const issue = $$$(this);
 
         const id = val('input.js-issues-list-check', issue);
         const title = txt('a.js-navigation-open', issue);

--- a/src/common/adapters/jira.js
+++ b/src/common/adapters/jira.js
@@ -1,10 +1,8 @@
-import $ from 'jquery';
-
-// TODO: remove jquery?
+/* global $$$ */
 
 const trim = (s) => s.replace(/^\s+|\s+$/g, '');
-const has = (sel, ctx) => $(sel, ctx).length > 0;
-const txt = (sel, ctx) => trim($(sel, ctx).text());
+const has = (sel, ctx) => $$$(sel, ctx).length > 0;
+const txt = (sel, ctx) => trim($$$(sel, ctx).text());
 
 const adapter = {
   inspect(loc, doc, fn) {
@@ -16,7 +14,7 @@ const adapter = {
       const title = txt('[data-field-id="summary"]', doc);
       return fn(null, [{ id, title }]);
     } else if (has('#issue-content', doc)) { // JIRA ticket page
-      const issue = $('#issue-content', doc);
+      const issue = $$$('#issue-content', doc);
       const id = txt('#key-val', issue);
       const title = txt('#summary-val', issue);
       return fn(null, [{ id, title }]);

--- a/src/common/adapters/pivotal.js
+++ b/src/common/adapters/pivotal.js
@@ -1,18 +1,16 @@
-import $ from 'jquery';
-
-// TODO: remove jquery?
+/* global $$$ */
 
 const trim = (s) => s.replace(/^\s+|\s+$/g, '');
-const has = (sel, ctx) => $(sel, ctx).length > 0;
-const val = (sel, ctx) => trim($(sel, ctx).val());
-const txt = (sel, ctx) => trim($(sel, ctx).text());
+const has = (sel, ctx) => $$$(sel, ctx).length > 0;
+const val = (sel, ctx) => trim($$$(sel, ctx).val());
+const txt = (sel, ctx) => trim($$$(sel, ctx).text());
 
 const cls = (ctx) => ['bug', 'chore', 'feature', 'release']
   .find((c) => ctx.hasClass(c));
 
 function multiple(elements, collapsed) {
   return elements.map(function extract() {
-    const story = $(this);
+    const story = $$$(this);
 
     const id = story.data('id').toString();
 
@@ -31,15 +29,15 @@ const adapter = {
     if (doc.body.id !== 'tracker') return fn(null, null);
 
     if (has('div.story .selector.selected', doc)) { // selected stories
-      const selection = $('div.story .selector.selected', doc).closest('.story');
+      const selection = $$$('div.story .selector.selected', doc).closest('.story');
       const tickets = multiple(selection, true);
       return fn(null, tickets);
     } else if (has('div.story .details', doc)) { // opened stories
-      const opened = $('div.story .details', doc).closest('.story');
+      const opened = $$$('div.story .details', doc).closest('.story');
       const tickets = multiple(opened, false);
       return fn(null, tickets);
     } else if (has('.story.maximized', doc)) { // single story in separate tab
-      const story = $('.story.maximized', doc);
+      const story = $$$('.story.maximized', doc);
       const id = val('aside input.id', story).replace(/^#/, '');
       const title = txt('.editor.name', story);
       const type = cls(story);

--- a/src/common/adapters/trello.js
+++ b/src/common/adapters/trello.js
@@ -1,10 +1,8 @@
-import $ from 'jquery';
-
-// TODO: remove jquery?
+/* global $$$ */
 
 const trim = (s) => s.replace(/^\s+|\s+$/g, '');
-const has = (sel, ctx) => $(sel, ctx).length > 0;
-const txt = (sel, ctx) => trim($(sel, ctx).text());
+const has = (sel, ctx) => $$$(sel, ctx).length > 0;
+const txt = (sel, ctx) => trim($$$(sel, ctx).text());
 
 const adapter = {
   inspect(loc, doc, fn) {

--- a/src/safari-extension/Info.plist
+++ b/src/safari-extension/Info.plist
@@ -57,6 +57,7 @@
 		<dict>
 			<key>Start</key>
 			<array>
+				<string>jquery.js</string>
 				<string>content.js</string>
 			</array>
 		</dict>

--- a/src/safari-extension/content.js
+++ b/src/safari-extension/content.js
@@ -1,7 +1,9 @@
-/* eslint-env browser */
+/* eslint-env browser, jquery */
 /* global safari */
 
 import stdsearch from '../common/search';
+
+window.$$$ = $.noConflict(true);
 
 function onMessage(event) {
   if (window.top === window) {

--- a/src/web-extension/content.js
+++ b/src/web-extension/content.js
@@ -1,7 +1,9 @@
-/* eslint-env browser */
+/* eslint-env browser, jquery */
 /* global chrome */
 
 import stdsearch from '../common/search';
+
+window.$$$ = $.noConflict(true);
 
 const runtime = chrome.runtime;
 

--- a/src/web-extension/manifest.json
+++ b/src/web-extension/manifest.json
@@ -13,11 +13,13 @@
        "http://*/*",
        "https://*/*"
      ],
-      "js": ["content.js"]
+     "js": [
+       "jquery.js",
+       "content.js"
+     ]
     }
   ],
   "web_accessible_resources": [
-    "dist/jquery.map"
   ],
   "permissions": [
     "tabs",


### PR DESCRIPTION
Use jQuery.noConflict(true) to avoid clashes with existing jQuery
instances on the content page. Looks a bit ugly and could be avoided by
bundling this and importing explicitely, buy hey… if that's what Mozilla
wants.