### PR TITLE
Set up code coverage reporting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,12 @@ node_modules
 # Optional npm cache directory
 .npm
 
+# Optional eslint cache
+.eslintcache
+
 # Build output
 dist
+
+# Test coverage reports
+.nyc_output/
+coverage/

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,12 @@
+{
+  "require": [
+    "babel-register"
+  ],
+  "include": [
+    "src/**"
+  ],
+  "extension": [
+    ".jsx"
+  ],
+  "all": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ node_js: "6"
 cache:
   directories:
     - "node_modules"
-script: "npm run lint && npm run test:coverage"
-after_success: "npm install coveralls@2.11.14 && nyc report --reporter=text-lcov | coveralls"
+script: "npm run lint && npm run test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: "node_js"
 node_js: "6"
-script: "npm run ci"
 cache:
   directories:
     - "node_modules"
+script: "npm run lint && npm run test:coverage"
+after_success: "npm install coveralls@2.11.14 && nyc report --reporter=text-lcov | coveralls"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,26 @@ Open Safari and enable the "Developer Menu" in the application preferences. Now
 go to the developer menu and open the "Extension Builder". Press the "+" button
 and add the `dist/tickety-tick.safariextension` that you just built.
 
-## Generated commands
+## Development
+
+### Generating coverage reports
+
+In order to generate code coverage reports locally, just run:
+
+```shell
+npm run test:coverage
+```
+
+Then, to generate and view HTML reports:
+
+```shell
+./node_modules/.bin/nyc report --reporter lcov
+open coverage/lcov-report/index.html
+```
+
+## Insights
+
+### Generated commands
 
 As mentioned earlier, in addition to branch names and commit messages,
 Tickety-Tick generates git commands to set up a branch with the proper name

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tickety-Tick [![Build Status](https://travis-ci.org/bitcrowd/tickety-tick.svg?branch=master)](https://travis-ci.org/bitcrowd/tickety-tick) [![Coverage Status](https://coveralls.io/repos/bitcrowd/tickety-tick/badge.svg?branch=master&service=github)](https://coveralls.io/github/bitcrowd/tickety-tick?branch=master)
+# Tickety-Tick [![Build Status](https://travis-ci.org/bitcrowd/tickety-tick.svg?branch=master)](https://travis-ci.org/bitcrowd/tickety-tick)
 
 *How do you name this branch? What is the message for that commit?*
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tickety-Tick [![Build Status](https://travis-ci.org/bitcrowd/tickety-tick.svg?branch=master)](https://travis-ci.org/bitcrowd/tickety-tick)
+# Tickety-Tick [![Build Status](https://travis-ci.org/bitcrowd/tickety-tick.svg?branch=master)](https://travis-ci.org/bitcrowd/tickety-tick) [![Coverage Status](https://coveralls.io/repos/bitcrowd/tickety-tick/badge.svg?branch=master&service=github)](https://coveralls.io/github/bitcrowd/tickety-tick?branch=master)
 
 *How do you name this branch? What is the message for that commit?*
 
@@ -48,9 +48,10 @@ Tickety-Tick is available for every major browser:
 
 In order to build the extension from source, run:
 
-```
+```shell
 npm install
 npm run build
+npm run checks
 ```
 
 For development use `npm run watch`. This will watch the files and rebuild the

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "watch": "NODE_ENV=production gulp watch",
     "clean": "gulp clean",
     "test": "NODE_ENV=test jasmine",
+    "test:coverage": "nyc npm test",
     "test:watch": "NODE_ENV=test nodemon --exec jasmine",
     "lint": "eslint '**/*.{js,jsx}'",
-    "ci": "npm run lint && npm run test"
+    "checks": "npm run lint && npm run test"
   },
   "devDependencies": {
     "autoprefixer": "^6.4.1",
@@ -38,6 +39,7 @@
     "jasmine": "=2.4.1",
     "jsdom": "^9.5.0",
     "nodemon": "^1.10.2",
+    "nyc": "^8.3.1",
     "react-addons-test-utils": "^15.3.1",
     "rimraf": "^2.5.4",
     "through2": "^2.0.1",


### PR DESCRIPTION
Sets up code coverage reporting using [istanbuljs/nyc](https://github.com/istanbuljs/nyc) and [coveralls.io](https://coveralls.io/).

- Requires a coveralls.io account to be set up (@bitboxer)
  - badge is already added to the [`README.md`](https://github.com/bitcrowd/tickety-tick/blob/f4c7065828e15f8fcf890440ee05dc0b8965af84/README.md)
- Exclude `src/web-extension` and `src/safari-extension` directories from report?
  - these directories contain files performing browser-specific entry points and hooks
  - seems like the tests would just re-create what's already written in the implementation
- Test `src/common/popup/render.jsx`