### PR TITLE
[#44] Tickety is 'having' "problems" with correctly escaping 'quotes'

### DIFF
--- a/spec/popup/format-spec.js
+++ b/spec/popup/format-spec.js
@@ -58,7 +58,9 @@ describe('format util', () => {
     });
 
     it('escapes any single-quotes in the input', () => {
-      expect(format.shellquote('esc\'; echo "pwned"')).toBe('\'esc\'\\\'\'; echo "pwned"\'');
+      const input = 'you\'; echo aren\'t "pwned"';
+      const quoted = '\'you\'\\\'\'; echo aren\'\\\'\'t "pwned"\'';
+      expect(format.shellquote(input)).toBe(quoted);
     });
   });
 

--- a/src/common/popup/utils/format.js
+++ b/src/common/popup/utils/format.js
@@ -5,7 +5,7 @@ const slugify = createSlug({ separator: '-' });
 const format = {};
 
 format.shellquote = function shellquote(s) {
-  if (typeof s === 'string') return `'${s.replace('\'', '\'\\\'\'')}'`;
+  if (typeof s === 'string') return `'${s.replace(/'/g, '\'\\\'\'')}'`;
   return '\'\'';
 };
 


### PR DESCRIPTION
Fixes #44. Thanks for reporting @tessi!

Background:

JavaScript `String.prototype.replace` can be called with a String or a RegExp as the first (match) argument. I expected the version with a String for matching to replace all occurrences, but apparently my memory tricked me.

Fix:

```js
s.replace('\'', '\'\\\'\'')
```

is now

```js
s.replace(/'/g, '\'\\\'\'')
```

Reference:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace