### PR TITLE
Language agnostic URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Currently, we support:
 Tickety-Tick is available for every major browser:
 
 - [Chrome/Chromium](https://chrome.google.com/webstore/detail/ciakolhgmfijpjbpcofoalfjiladihbg)
-- [Firefox](https://addons.mozilla.org/de/firefox/addon/tickety-tick/)
-- [Opera](https://addons.opera.com/en/extensions/details/tickety-tick/)
+- [Firefox](https://addons.mozilla.org/firefox/addon/tickety-tick/)
+- [Opera](https://addons.opera.com/extensions/details/tickety-tick/)
 - For Safari, you need to build it yourself (see below)
 
 ## Building


### PR DESCRIPTION
Removes hardcoded language slugs (`de` and `en`) from AMO and Opera Addons URLs.