### PR TITLE
Feature/54 extension can t be installed on new firefox quantum

### DIFF
--- a/src/web-extension/manifest.json
+++ b/src/web-extension/manifest.json
@@ -27,7 +27,7 @@
     "clipboardWrite"
   ],
   "browser_action": {
-    "default_name": "Git Branch/Message",
+    "default_title": "Git Branch/Message",
     "default_icon": "icons/icon-128.png",
     "default_popup": "popup/popup.html"
   },


### PR DESCRIPTION
Apparently browser_action.default_name is deprecated:

https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/browser_action
https://developer.chrome.com/extensions/browserAction
https://developer.chrome.com/extensions/tut_migration_to_manifest_v2

Now I can install the extension again temporarily, but still not permanently:

`about:debugging#addons`
![screen shot 2017-10-05 at 17 08 24](https://user-images.githubusercontent.com/239398/31234688-d741f5be-a9ef-11e7-965f-786021be5fc9.png)

`about:addons`
![screen shot 2017-10-05 at 17 07 39](https://user-images.githubusercontent.com/239398/31234650-bf4f8ea8-a9ef-11e7-9341-b64fcc36fea4.png)

@pmeinhardt do you know if something else needs to be done? Or is this some security feature.