### PR TITLE
[#54] Extension can't be installed on new Firefox Quantum

### DIFF
--- a/src/web-extension/manifest.json
+++ b/src/web-extension/manifest.json
@@ -4,6 +4,11 @@
   "version": "#{VERSION}",
   "description": "#{DESCRIPTION}",
   "icons": {},
+  "applications": {
+    "gecko": {
+      "id": "tickety-tick@bitcrowd.net"
+    }
+  },
   "background": {
     "scripts": ["background.js"]
   },


### PR DESCRIPTION
Adds an extension ID as recommended by MDN:
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Alternative_distribution_options/Sideloading_add-ons#Preparing_your_add-on