### PR TITLE
[#64] Warnings when installing with a recent chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ Navigate to the [chrome://extensions](chrome://extensions) page, enable
 
 ### Firefox
 
-For Firefox >48: Build the extensions with `WITH_ADDON_ID=true yarn build`
+For Firefox >=48: Build the extensions with `WITH_GECKO_ID=true yarn build`
 
 If you just want to try out and debug the extension, go to
 [about:debugging#addons](about:debugging#addons). Then press "Load Temporary
 Add-On" and select the `manifest.json` from the built extension directory.
 
-If you want to install this addon permanently goto [about:addons](about:addons)
-and klick on the small cogs icon. Select `Install Addon from file...` and choose
+If you want to install this addon permanently go to [about:addons](about:addons)
+and click on the small cog icon. Select `Install Add-on From File...` and choose
 `dist/web-extension.zip`.
 
 ### Opera

--- a/README.md
+++ b/README.md
@@ -67,9 +67,15 @@ Navigate to the [chrome://extensions](chrome://extensions) page, enable
 
 ### Firefox
 
+For Firefox >48: Build the extensions with `WITH_ADDON_ID=true yarn build`
+
 If you just want to try out and debug the extension, go to
 [about:debugging#addons](about:debugging#addons). Then press "Load Temporary
 Add-On" and select the `manifest.json` from the built extension directory.
+
+If you want to install this addon permanently goto [about:addons](about:addons)
+and klick on the small cogs icon. Select `Install Addon from file...` and choose
+`dist/web-extension.zip`.
 
 ### Opera
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -96,7 +96,7 @@ function js(version) {
 }
 
 function manifest(version, pkginfo) {
-  const process = (file, enc, cb) => {
+  const postProcess = (file, enc, cb) => {
     const mf = JSON.parse(file.contents.toString());
 
     mf.name = pkginfo.name;
@@ -110,6 +110,13 @@ function manifest(version, pkginfo) {
       128: 'icons/icon-128.png',
     };
 
+    if(process.env.WITH_ADDON_ID) {
+      mf.applications = {
+        "gecko": {
+          "id": "tickety-tick@bitcrowd.net"
+        }
+      };
+    }
     // eslint-disable-next-line no-param-reassign
     file.contents = Buffer.from(JSON.stringify(mf));
 
@@ -117,7 +124,7 @@ function manifest(version, pkginfo) {
   };
 
   return gulp.src(src[version]('manifest.json'))
-    .pipe(through.obj(process))
+    .pipe(through.obj(postProcess))
     .pipe(gulp.dest(dist[version]()));
 }
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -110,7 +110,7 @@ function manifest(version, pkginfo) {
       128: 'icons/icon-128.png',
     };
 
-    if (process.env.WITH_ADDON_ID) {
+    if (process.env.WITH_GECKO_ID) {
       mf.applications = {
         gecko: {
           id: 'tickety-tick@bitcrowd.net',

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -110,13 +110,14 @@ function manifest(version, pkginfo) {
       128: 'icons/icon-128.png',
     };
 
-    if(process.env.WITH_ADDON_ID) {
+    if (process.env.WITH_ADDON_ID) {
       mf.applications = {
-        "gecko": {
-          "id": "tickety-tick@bitcrowd.net"
-        }
+        gecko: {
+          id: 'tickety-tick@bitcrowd.net',
+        },
       };
     }
+
     // eslint-disable-next-line no-param-reassign
     file.contents = Buffer.from(JSON.stringify(mf));
 

--- a/src/web-extension/manifest.json
+++ b/src/web-extension/manifest.json
@@ -4,11 +4,6 @@
   "version": "#{VERSION}",
   "description": "#{DESCRIPTION}",
   "icons": {},
-  "applications": {
-    "gecko": {
-      "id": "tickety-tick@bitcrowd.net"
-    }
-  },
   "background": {
     "scripts": ["background.js"]
   },


### PR DESCRIPTION
Since the addon-ID is only needed when manually installing the plugin in newer versions
of firefox and also it is only needed if you want to install it permanently I added an env variable to activate the injection of the 'fake' addon ID. 

I put some references to #65 
