### PR TITLE
release 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "name": "tickety-tick",
   "description": "A browser extension that helps you to create commit messages and branch names from story trackers.",
   "author": "Bodo Tasche <bodo@bitcrowd.net>",


### PR DESCRIPTION
Since we worked quite a lot on tickety-tick, I would try a new release also to finally achive 
#50.
Since the Firefox release seems to me to be the most crucial and hardest one, I will try and start with that one. 
before we can release however we need: 
- [x] #65 merged. 

In order to be in sync with the version numbers, I'd like to tick the number to 1.2.2, so we can later also release on chrome/opera. 