### PR TITLE
[#72] Remove jQuery dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   },
   "dependencies": {
     "bootstrap": "4.0.0-alpha.4",
-    "jquery": "3.2.1",
     "octicons": "7.0.1",
     "prop-types": "15.6.0",
     "react": "16.1.1",

--- a/spec/support/helpers/setup.js
+++ b/spec/support/helpers/setup.js
@@ -2,12 +2,9 @@ import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 import { JSDOM } from 'jsdom';
-import jquery from 'jquery';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 global.window = new JSDOM('<html><body></body></html>').window;
 global.document = global.window.document;
 global.navigator = global.window.navigator;
-
-global.$$$ = jquery(global.window);

--- a/src/common/adapters/github.js
+++ b/src/common/adapters/github.js
@@ -1,14 +1,15 @@
-import { $find, $has, $map, $text, $value } from './helpers';
+import { $all, $has, $text, $value } from './helpers';
 
 const adapter = {
   inspect(loc, doc, fn) {
     if ($has('.issues-listing .js-issue-row.selected', doc)) {
-      const issues = $find('.issues-listing .js-issue-row.selected', doc);
+      const issues = $all('.issues-listing .js-issue-row.selected', doc);
 
-      const tickets = $map(issues, (i, issue) => {
+      const tickets = issues.map((issue) => {
         const id = $value('input.js-issues-list-check', issue);
         const title = $text('a.js-navigation-open', issue);
-        const type = $has('.labels .label:contains(bug)', issue) ? 'bug' : 'feature';
+        const labels = $all('.labels .label', issue);
+        const type = labels.some(l => /bug/i.test(l.textContent)) ? 'bug' : 'feature';
 
         return { id, title, type };
       });
@@ -27,9 +28,9 @@ const adapter = {
     // github project
     if ($has('.project-columns .project-card', doc)) {
       const openProjectCardSelector = '.project-columns .project-card[data-card-state=\'["open"]\']';
-      const projectCards = $find(openProjectCardSelector, doc);
+      const projectCards = $all(openProjectCardSelector, doc);
 
-      const tickets = $map(projectCards, (_, card) => {
+      const tickets = projectCards.map((card) => {
         const id = JSON.parse(card.dataset.cardTitle).slice(-2, -1)[0];
         const title = $text('a.h5', card);
         const type = JSON.parse(card.dataset.cardLabel).includes('bug') ? 'bug' : 'feature';

--- a/src/common/adapters/helpers.js
+++ b/src/common/adapters/helpers.js
@@ -1,53 +1,73 @@
-/* global $$$ */
-
 function trim(string) {
-  return string.replace(/^\s+|\s+$/g, '');
+  return string ? string.replace(/^\s+|\s+$/g, '') : null;
 }
 
-function $data(context, key) {
-  const node = $$$(context);
-  return node.data(key);
+// Finders
+
+function $find(selector, context) {
+  return context.querySelector(selector);
 }
+
+function $all(selector, context) {
+  return Array.from(context.querySelectorAll(selector));
+}
+
+// Traversal
+
+function $closest(selector, context) {
+  if (typeof context.closest !== 'function') {
+    // Shim Element.closest for browsers that do not support it (and jsdom):
+    // https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+    let node = context;
+
+    while (node && node.nodeType === 1) {
+      if (node.matches(selector)) return node;
+      node = node.parentNode;
+    }
+
+    return null;
+  }
+
+  return context.closest(selector);
+}
+
+// Properties
 
 function $attr(selector, context, key) {
-  const node = $$$(selector, context);
-  return node.attr(key);
+  const node = $find(selector, context);
+  return node ? node.getAttribute(key) : null;
+}
+
+function $classed(node, cls) {
+  return node.classList.contains(cls);
+}
+
+function $data(node, key) {
+  return node.dataset[key];
 }
 
 function $has(selector, context) {
-  const nodes = $$$(selector, context);
-  return nodes.length > 0;
-}
-
-function $classed(context, cls) {
-  return $$$(context).hasClass(cls);
-}
-
-function $find(selector, context) {
-  return $$$(selector, context);
-}
-
-function $map(collection, fn) {
-  return $$$(collection).map(fn).get();
+  return $find(selector, context) !== null;
 }
 
 function $text(selector, context) {
-  const txt = $$$(selector, context).text();
-  return trim(txt);
+  const node = $find(selector, context);
+  return node ? trim(node.textContent) : null;
 }
 
 function $value(selector, context) {
-  const val = $$$(selector, context).val();
-  return trim(val);
+  const node = $find(selector, context);
+  return node ? trim(node.value || node.getAttribute('value')) : null;
 }
 
 export {
-  $data,
+  $all,
   $attr,
+  $classed,
+  $closest,
+  $data,
   $find,
   $has,
-  $classed,
-  $map,
   $text,
   $value,
   trim,

--- a/src/common/adapters/jira.js
+++ b/src/common/adapters/jira.js
@@ -1,6 +1,7 @@
 import { $find, $has, $text, $attr } from './helpers';
 
 const TYPES = ['bug', 'chore'];
+
 const normalizeType = (type) => {
   const sanitizedType = type && type.toLowerCase();
   if (TYPES.indexOf(sanitizedType) > -1) return sanitizedType;

--- a/src/common/adapters/pivotal.js
+++ b/src/common/adapters/pivotal.js
@@ -1,9 +1,9 @@
-import { $data, $find, $has, $classed, $text, $value } from './helpers';
+import { $all, $classed, $closest, $data, $find, $has, $text, $value } from './helpers';
 
 const cls = ctx => ['bug', 'chore', 'feature', 'release'].find(c => $classed(ctx, c));
 
 function multiple(elements, collapsed) {
-  return elements.map((i, story) => {
+  return elements.map((story) => {
     const id = $data(story, 'id').toString();
 
     const title = collapsed
@@ -13,7 +13,7 @@ function multiple(elements, collapsed) {
     const type = cls(story);
 
     return { id, title, type };
-  }).get();
+  });
 }
 
 const adapter = {
@@ -21,11 +21,11 @@ const adapter = {
     if (doc.body.id !== 'tracker') return fn(null, null);
 
     if ($has('div.story .selector.selected', doc)) { // selected stories
-      const selection = $find('div.story .selector.selected', doc).closest('.story');
+      const selection = $all('div.story .selector.selected', doc).map(e => $closest('.story', e));
       const tickets = multiple(selection, true);
       return fn(null, tickets);
     } else if ($has('div.story .details', doc)) { // opened stories
-      const opened = $find('div.story .details', doc).closest('.story');
+      const opened = $all('div.story .details', doc).map(e => $closest('.story', e));
       const tickets = multiple(opened, false);
       return fn(null, tickets);
     } else if ($has('.story.maximized', doc)) { // single story in separate tab

--- a/src/safari-extension/Info.plist
+++ b/src/safari-extension/Info.plist
@@ -57,7 +57,6 @@
 		<dict>
 			<key>Start</key>
 			<array>
-				<string>jquery.js</string>
 				<string>content.js</string>
 			</array>
 		</dict>

--- a/src/safari-extension/content.js
+++ b/src/safari-extension/content.js
@@ -1,9 +1,7 @@
-/* eslint-env browser, jquery */
+/* eslint-env browser */
 /* global safari */
 
 import stdsearch from '../common/search';
-
-window.$$$ = $.noConflict(true);
 
 function onMessage(event) {
   if (window.top === window) {

--- a/src/web-extension/content.js
+++ b/src/web-extension/content.js
@@ -1,9 +1,7 @@
-/* eslint-env browser, jquery */
+/* eslint-env browser */
 /* global chrome */
 
 import stdsearch from '../common/search';
-
-window.$$$ = $.noConflict(true);
 
 const { runtime } = chrome;
 

--- a/src/web-extension/manifest.json
+++ b/src/web-extension/manifest.json
@@ -19,10 +19,7 @@
        "http://*/*",
        "https://*/*"
      ],
-     "js": [
-       "jquery.js",
-       "content.js"
-     ]
+     "js": ["content.js"]
     }
   ],
   "web_accessible_resources": [

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -99,10 +99,6 @@ config.plugin('extract')
 config.plugin('copy')
   .use(CopyWebpackPlugin, [[
     {
-      from: './node_modules/jquery/dist/jquery.js',
-      flatten: true,
-    },
-    {
       from: src.common('icons', '*.png'),
       flatten: true,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3827,7 +3827,7 @@ joi@^6.10.1:
     moment "2.x.x"
     topo "1.x.x"
 
-"jquery@1.9.1 - 3", jquery@3.2.1:
+"jquery@1.9.1 - 3":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
 


### PR DESCRIPTION
Based on changes in #71. Therefore needs to be rebased after that is merged and for review, focus on the commits starting at `[#72] …`.

Removes jQuery as a dependency. Instead implements adapter helpers using native DOM APIs.

See the links for detailed information on browser support and references to the MDN docs et cetera.

- [`Element.querySelector`/`querySelectorAll`](https://caniuse.com/#search=queryselector)
- [`Element.dataset`](https://caniuse.com/#search=dataset)
- [`Element.classList`](https://caniuse.com/#search=classlist)
- [`Element.getAttribute`](https://caniuse.com/#search=getattribute)
- [`Element.closest`](https://caniuse.com/#search=closest) (with a shim for DOM implementations that do not support it)
- `Element.textContent`
- …

Unit tests are passing, but we need to make sure everything still works in the **supported browsers** (`jsdom` may behave differently, e.g. for `Element.closest`) and **story trackers**.