### PR TITLE
Conditionally zip built web-extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ and add the `dist/tickety-tick.safariextension` that you just built.
 
 ## Development
 
+### Building releases
+
+Chrome Web Store and Firefox Addons require you to submit extensions as a
+single zip archive. To build and zip the extension for a release, run:
+
+```shell
+yarn bundle:chrome
+yarn bundle:firefox
+```
+
 ### Developing Tickety-Tick
 
 For development use `yarn watch:[browser]`. This will watch the files and

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "watch:safari": "npm run build:safari -- --watch",
     "open:chrome": "./script/open-in-chrome ./dist/chrome https://github.com/bitcrowd/tickety-tick",
     "open:firefox": "web-ext run --source-dir ./dist/firefox --pref startup.homepage_welcome_url=https://github.com/bitcrowd/tickety-tick",
+    "bundle:chrome": "cross-env BUNDLE=true npm run build:chrome",
+    "bundle:firefox": "cross-env BUNDLE=true npm run build:firefox",
     "lint": "eslint '**/*.{js,jsx}'",
     "test": "cross-env NODE_ENV=test jasmine",
     "test:coverage": "nyc npm test",
@@ -60,7 +62,7 @@
     "web-ext": "2.2.2",
     "webpack": "3.8.1",
     "webpack-chain": "4.4.2",
-    "zip-webpack-plugin": "^2.1.0"
+    "zip-webpack-plugin": "2.1.0"
   },
   "dependencies": {
     "bootstrap": "4.0.0-alpha.4",

--- a/webpack.webext.babel.js
+++ b/webpack.webext.babel.js
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
-import path from 'path';
 import ZipWebpackPlugin from 'zip-webpack-plugin';
 
 import config, { src, dist } from './webpack.common';
@@ -47,12 +46,13 @@ config.plugin('copy').tap(([patterns]) => [[
   },
 ]]);
 
-config.plugin('zip')
-  .use(ZipWebpackPlugin, [
-    {
-      path: path.join(__dirname, 'dist'),
-      filename: variant,
-    },
-  ]);
+config.when(process.env.BUNDLE === 'true', cfg =>
+  cfg.plugin('zip')
+    .use(ZipWebpackPlugin, [
+      {
+        path: dist(),
+        filename: variant,
+      },
+    ]));
 
 export default config.toConfig();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7454,7 +7454,7 @@ zip-stream@^1.1.0:
     lodash "^4.8.0"
     readable-stream "^2.0.0"
 
-zip-webpack-plugin@^2.1.0:
+zip-webpack-plugin@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/zip-webpack-plugin/-/zip-webpack-plugin-2.1.0.tgz#e9d060ccd6afcf7c60b09b6e2e56275b181e1d72"
   dependencies:


### PR DESCRIPTION
Add an environment variable to conditionally zip the built extension
for WebExtension API-compatible browsers and two convenience npm scripts
for building releases:

```shell
yarn bundle:chrome
yarn bundle:firefox
```

Or, manually:

```shell
BUNDLE=true yarn build:firefox
```