### PR TITLE
 [#73] Remove Bootstrap (alpha) as a dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "zip-webpack-plugin": "2.1.0"
   },
   "dependencies": {
-    "bootstrap": "4.0.0-alpha.4",
+    "bootstrap": "4.0.0-beta.2",
     "octicons": "7.0.1",
     "prop-types": "15.6.0",
     "react": "16.1.1",

--- a/src/common/popup/components/no-tickets.jsx
+++ b/src/common/popup/components/no-tickets.jsx
@@ -6,7 +6,7 @@ const href = 'https://github.com/bitcrowd/tickety-tick/issues';
 
 function NoTickets() {
   return (
-    <div className="text-xs-center m-b-2">
+    <div className="text-center m-b-2">
       <h5 className="m-t-2 m-b-2">No tickets found on this page.</h5>
       <h6>
         Did you select or open any tickets?

--- a/src/common/popup/components/ticket-list.jsx
+++ b/src/common/popup/components/ticket-list.jsx
@@ -18,11 +18,11 @@ function TicketListItem({ ticket }) {
   return (
     <li className="list-group-item list-group-item-tt">
       <div className="container list-group-container">
-        <div className="row">
-          <div className="col-xs-7">
+        <div className="row no-gutters">
+          <div className="col-7">
             <h6 className="list-group-heading">{ticket.title}</h6>
           </div>
-          <div className="col-xs-5 text-xs-right">
+          <div className="col-5 text-xs-right">
             <CopyButton
               className="btn btn-primary btn-sm"
               title="Branch name"

--- a/src/common/popup/popup.scss
+++ b/src/common/popup/popup.scss
@@ -1,12 +1,11 @@
 // Customization
+
 @import "styles/settings";
 
 // Core variables and mixins
+@import '~bootstrap/scss/functions';
 @import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins";
-
-// Reset and dependencies
-@import "~bootstrap/scss/normalize";
 
 // Core CSS
 @import "~bootstrap/scss/reboot";

--- a/src/common/popup/styles/_additions.scss
+++ b/src/common/popup/styles/_additions.scss
@@ -3,7 +3,6 @@
 .popup {
   width: 315px;
   min-height: 210px;
-  padding-top: 42px;
 }
 
 // Logos
@@ -22,8 +21,9 @@
 // Navs
 
 .navbar-tt {
-  border-bottom: 1px solid $gray-lighter;
+  border-bottom: 1px solid $gray-200;
   background: #fff;
+  margin-bottom: 5px;
 }
 
 .nav-text {

--- a/src/common/popup/styles/_settings.scss
+++ b/src/common/popup/styles/_settings.scss
@@ -4,8 +4,10 @@ $enable-flex: true;
 
 // Typography
 
-$font-size-root: 12px;
+$font-size-base: 0.7rem;
 
 // Color
 
-$brand-primary: #c32f34;
+$primary: #c32f34;
+
+$navbar-padding-y: 5px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1065,12 +1065,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bootstrap@4.0.0-alpha.4:
-  version "4.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-alpha.4.tgz#823cb353d6c50a38df98aa18ec4df56ef0355e7a"
-  dependencies:
-    jquery "1.9.1 - 3"
-    tether "^1.1.1"
+bootstrap@4.0.0-beta.2:
+  version "4.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-beta.2.tgz#4d67d2aa2219f062cd90bc1247e6747b9e8fd051"
 
 boundary@^1.0.1:
   version "1.0.1"
@@ -3826,10 +3823,6 @@ joi@^6.10.1:
     isemail "1.x.x"
     moment "2.x.x"
     topo "1.x.x"
-
-"jquery@1.9.1 - 3":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
 
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.3.2"
@@ -6657,10 +6650,6 @@ test-exclude@^4.1.1:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
-
-tether@^1.1.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/tether/-/tether-1.4.1.tgz#78112ef21adf2aea68cd90e72185f43d9ffc44e8"
 
 text-table@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Since it may be too hard to remove bootstrap entirely, I decided updating it for now. Sadly there is still only the beta release :( 