### PR TITLE
Add webpack-build-notifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "sass-loader": "6.0.6",
     "web-ext": "2.2.2",
     "webpack": "3.8.1",
+    "webpack-build-notifier": "0.1.21",
     "webpack-chain": "4.4.2",
     "zip-webpack-plugin": "2.1.0"
   },

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,6 +5,7 @@ import path from 'path';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
+import NotifierPlugin from 'webpack-build-notifier';
 
 import Config from 'webpack-chain';
 
@@ -103,6 +104,11 @@ config.plugin('copy')
       flatten: true,
     },
   ]]);
+
+config.plugin('notifier')
+  .use(NotifierPlugin, [{
+    title: 'Tickety-Tick Build',
+  }]);
 
 config.devtool('source-map');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7105,6 +7105,14 @@ webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
+webpack-build-notifier@0.1.21:
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/webpack-build-notifier/-/webpack-build-notifier-0.1.21.tgz#8970ff44a6a290fa636fb1385045ebd08a089ab0"
+  dependencies:
+    ansi-regex "^2.0.0"
+    node-notifier "5.1.2"
+    strip-ansi "^3.0.1"
+
 webpack-chain@4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/webpack-chain/-/webpack-chain-4.4.2.tgz#6234884f59c096ebd622535c6a69d31e8440ff99"


### PR DESCRIPTION
Add webpack plugin to show notifications on successful or failed builds.
This makes it easier to know when building has finished and you can
refresh, especially when you have the browser window open in the
foreground most of the time.

-- https://github.com/RoccoC/webpack-build-notifier