### PR TITLE
[#90] No tickets found on JIRA backlog view

### DIFF
--- a/spec/adapters/jira-spec.js
+++ b/spec/adapters/jira-spec.js
@@ -2,6 +2,8 @@ import { JSDOM } from 'jsdom';
 
 import adapter from '../../src/common/adapters/jira';
 
+// parts of the dom of the jira backlog issue-list
+// contains two tickets - one of them being selected
 const BACKLOG = `
   <div class="ghx-backlog-column">
     <div class="ghx-backlog-card ghx-selected">
@@ -31,10 +33,38 @@ const BACKLOG = `
         </div>
       </div>
     </div>
+    <div class="ghx-backlog-card">
+      <div class="ghx-issue-content">
+        <div class="ghx-row ghx-plan-main-fields">
+          <span class="ghx-backlog-card-expander-spacer"></span>
+          <span class="ghx-type items-spacer" title="Bug">
+            <img src="https://someorg.atlassian.net/secure/viewavatar?size=xsmall&amp;avatarId=12345&amp;avatarType=issuetype">
+          </span>
+          <div class="ghx-summary" data-tooltip="A Random JIRA Bug Issue">
+            <span class="ghx-inner">A Random JIRA Bug Issue</span>
+          </div>
+        </div>
+        <div class="ghx-row ghx-end ghx-items-container">
+          <span class="aui-lozenge ghx-label ghx-label-single ghx-label-3" title="Chores" data-epickey="UXPL-123">
+            Chores
+          </span>
+          <span class="ghx-end ghx-items-container">
+            <a href="/browse/UXPL-47" title="UXPL-47" class="ghx-key js-key-link">
+              UXPL-47
+            </a>
+            <span class="ghx-priority" title="Low">
+              <img src="https://someorg.atlassian.net/images/icons/priorities/low.svg">
+            </span>
+            <span class="aui-badge ghx-spacer ghx-statistic-badge"></span>
+          </span>
+        </div>
+      </div>
+    </div>
   </div>
 `;
 const BUG_BACKLOG = BACKLOG.replace(/Story/, 'Bug');
 const CHORE_BACKLOG = BACKLOG.replace(/Story/, 'Chore');
+const BACKLOG_TWO_TICKETS_SELECTED = BACKLOG.replace('<div class="ghx-backlog-card">', '<div class="ghx-backlog-card ghx-selected">');
 
 const STORYPAGE = `
   <div id="issue-content">
@@ -166,6 +196,17 @@ describe('jira adapter', () => {
   it('extracts chore tickets from the backlog', () => {
     const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'chore' }];
     adapter.inspect(null, doc(CHORE_BACKLOG), (err, res) => {
+      expect(err).toBe(null);
+      expect(res).toEqual(expected);
+    });
+  });
+
+  it('extracts tickets from the backlog when multiple tickets are selected', () => {
+    const expected = [
+      { id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'feature' },
+      { id: 'UXPL-47', title: 'A Random JIRA Bug Issue', type: 'bug' },
+    ];
+    adapter.inspect(null, doc(BACKLOG_TWO_TICKETS_SELECTED), (err, res) => {
       expect(err).toBe(null);
       expect(res).toEqual(expected);
     });

--- a/spec/adapters/jira-spec.js
+++ b/spec/adapters/jira-spec.js
@@ -2,19 +2,39 @@ import { JSDOM } from 'jsdom';
 
 import adapter from '../../src/common/adapters/jira';
 
-const SIDEBAR = `
-  <div>
-    <div class="ghx-fieldname-issuekey">
-      <a href="#">UXPL-39</a>
-    </div>
-    <div data-field-id="summary">A Random JIRA Sidebar Issue</div>
-    <div data-issue-key="UXPL-39">
-      <span class="ghx-type" title="Story"></span>
+const BACKLOG = `
+  <div class="ghx-backlog-column">
+    <div class="ghx-backlog-card ghx-selected">
+      <div class="ghx-issue-content">
+        <div class="ghx-row ghx-plan-main-fields">
+          <span class="ghx-backlog-card-expander-spacer"></span>
+          <span class="ghx-type items-spacer" title="Story">
+            <img src="https://someorg.atlassian.net/secure/viewavatar?size=xsmall&amp;avatarId=12345&amp;avatarType=issuetype">
+          </span>
+          <div class="ghx-summary" data-tooltip="A Random JIRA Backlog Issue">
+            <span class="ghx-inner">A Random JIRA Backlog Issue</span>
+          </div>
+        </div>
+        <div class="ghx-row ghx-end ghx-items-container">
+          <span class="aui-lozenge ghx-label ghx-label-single ghx-label-3" title="Chores" data-epickey="UXPL-123">
+            Chores
+          </span>
+          <span class="ghx-end ghx-items-container">
+            <a href="/browse/UXPL-39" title="UXPL-39" class="ghx-key js-key-link">
+              UXPL-39
+            </a>
+            <span class="ghx-priority" title="Medium">
+              <img src="https://someorg.atlassian.net/images/icons/priorities/medium.svg">
+            </span>
+            <span class="aui-badge ghx-spacer ghx-statistic-badge"></span>
+          </span>
+        </div>
+      </div>
     </div>
   </div>
 `;
-const BUG_SIDEBAR = SIDEBAR.replace(/Story/, 'Bug');
-const CHORE_SIDEBAR = SIDEBAR.replace(/Story/, 'Chore');
+const BUG_BACKLOG = BACKLOG.replace(/Story/, 'Bug');
+const CHORE_BACKLOG = BACKLOG.replace(/Story/, 'Chore');
 
 const STORYPAGE = `
   <div id="issue-content">
@@ -127,25 +147,25 @@ describe('jira adapter', () => {
     });
   });
 
-  it('extracts tickets from the sidebar', () => {
-    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Sidebar Issue', type: 'feature' }];
-    adapter.inspect(null, doc(SIDEBAR), (err, res) => {
+  it('extracts tickets from the backlog', () => {
+    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'feature' }];
+    adapter.inspect(null, doc(BACKLOG), (err, res) => {
       expect(err).toBe(null);
       expect(res).toEqual(expected);
     });
   });
 
-  it('extracts bug tickets from the sidebar', () => {
-    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Sidebar Issue', type: 'bug' }];
-    adapter.inspect(null, doc(BUG_SIDEBAR), (err, res) => {
+  it('extracts bug tickets from the backlog', () => {
+    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'bug' }];
+    adapter.inspect(null, doc(BUG_BACKLOG), (err, res) => {
       expect(err).toBe(null);
       expect(res).toEqual(expected);
     });
   });
 
-  it('extracts chore tickets from the sidebar', () => {
-    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Sidebar Issue', type: 'chore' }];
-    adapter.inspect(null, doc(CHORE_SIDEBAR), (err, res) => {
+  it('extracts chore tickets from the backlog', () => {
+    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'chore' }];
+    adapter.inspect(null, doc(CHORE_BACKLOG), (err, res) => {
       expect(err).toBe(null);
       expect(res).toEqual(expected);
     });

--- a/src/common/adapters/jira.js
+++ b/src/common/adapters/jira.js
@@ -1,4 +1,4 @@
-import { $find, $has, $text, $attr } from './helpers';
+import { $all, $find, $has, $text, $attr } from './helpers';
 
 const TYPES = ['bug', 'chore'];
 
@@ -22,11 +22,14 @@ const adapter = {
 
     if ($has('.ghx-backlog-column .ghx-backlog-card.ghx-selected', doc)) {
       // ticket list with backlog and sprints
-      const issue = $find('.ghx-backlog-column .ghx-backlog-card.ghx-selected', doc);
-      const id = $text('.ghx-key', issue);
-      const title = $text('.ghx-summary .ghx-inner', issue);
-      const type = normalizeType($attr('.ghx-type', issue, 'title'));
-      return fn(null, [{ id, title, type }]);
+      const issueCssPath = '.ghx-backlog-column .ghx-backlog-card.ghx-selected';
+      const issues = $all(issueCssPath, doc).map((issue) => {
+        const id = $text('.ghx-key', issue);
+        const title = $text('.ghx-summary .ghx-inner', issue);
+        const type = normalizeType($attr('.ghx-type', issue, 'title'));
+        return { id, title, type };
+      });
+      return fn(null, issues);
     } else if ($has('#issue-content', doc)) {
       // ticket show-page, when a single ticket is opened full-screen
       const issue = $find('#issue-content', doc);

--- a/src/common/adapters/jira.js
+++ b/src/common/adapters/jira.js
@@ -20,18 +20,22 @@ const adapter = {
   inspect(loc, doc, fn) {
     if (doc.body.id !== 'jira') return fn(null, null);
 
-    if ($has('.ghx-fieldname-issuekey a', doc)) { // JIRA sidebar
-      const id = $text('.ghx-fieldname-issuekey a', doc);
-      const title = $text('[data-field-id="summary"]', doc);
-      const type = normalizeType($attr(`[data-issue-key="${id}"] .ghx-type`, doc, 'title'));
+    if ($has('.ghx-backlog-column .ghx-backlog-card.ghx-selected', doc)) {
+      // ticket list with backlog and sprints
+      const issue = $find('.ghx-backlog-column .ghx-backlog-card.ghx-selected', doc);
+      const id = $text('.ghx-key', issue);
+      const title = $text('.ghx-summary .ghx-inner', issue);
+      const type = normalizeType($attr('.ghx-type', issue, 'title'));
       return fn(null, [{ id, title, type }]);
-    } else if ($has('#issue-content', doc)) { // JIRA ticket page
+    } else if ($has('#issue-content', doc)) {
+      // ticket show-page, when a single ticket is opened full-screen
       const issue = $find('#issue-content', doc);
       const id = $text('#key-val', issue);
       const title = ticketPageTitle(issue);
       const type = normalizeType($text('#type-val', issue));
       return fn(null, [{ id, title, type }]);
-    } else if ($has('.ghx-columns .ghx-issue.ghx-selected', doc)) { // Board view
+    } else if ($has('.ghx-columns .ghx-issue.ghx-selected', doc)) {
+      // Board view, when a ticket is opened in a modal window
       const issue = $find('.ghx-columns .ghx-issue.ghx-selected', doc);
       const id = $attr('.ghx-key', issue, 'aria-label');
       const title = $text('.ghx-summary', issue);


### PR DESCRIPTION
Enables finding tickets on the jira backlog view again. Also renames this within jira.js from `sidebar` to `backlog` which makes things a little more clear IMO