### PR TITLE
Fix popup layout in Safari

### DIFF
--- a/src/safari-extension/Info.plist
+++ b/src/safari-extension/Info.plist
@@ -28,7 +28,7 @@
 				<key>Identifier</key>
 				<string>tickety-tick.popup</string>
 				<key>Width</key>
-				<real>285</real>
+				<real>315</real>
 			</dict>
 		</array>
 		<key>Toolbar Items</key>


### PR DESCRIPTION
### Fix popup width

The Tickety-Tick popup looked broken in Safari. Increasing the popup
width via the `Info.plist` apparently fixes the issue 🤷‍♂️ 

**Before**

<img width="321" alt="image" src="https://user-images.githubusercontent.com/706519/47262072-b5e70300-d4cd-11e8-9f83-3165042bb8ce.png">

**After**

<img width="389" alt="image" src="https://user-images.githubusercontent.com/706519/47262067-a071d900-d4cd-11e8-915f-0f3e1cc6e940.png">

The buttons still look a bit weird… I'll see whether I can follow up on this.