### PR TITLE
Fix type in build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npm-run-all -n build:chrome build:firefox build:safari",
     "pack": "npm-run-all -n pack:chrome pack:firefox pack:safari",
     "build:chrome": "cross-env VARIANT=chrome webpack --mode=production --config webpack.webext.babel.js",
-    "build:firefox": "cross-env VARIANT=firefox webpack --mode=productionp --config webpack.webext.babel.js",
+    "build:firefox": "cross-env VARIANT=firefox webpack --mode=production --config webpack.webext.babel.js",
     "build:firefox-local": "cross-env VARIANT=firefox-local webpack --mode=production --config webpack.webext.babel.js",
     "build:safari": "webpack --mode=production --config webpack.safari.babel.js",
     "watch:chrome": "npm run build:chrome -- --watch",


### PR DESCRIPTION
Fix a typo in the package.json passing an invalid option "productionp" instead of "production" as the mode to build the Firefox release 👋 