### PR TITLE
[#110] Add support for Ora

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ Tickety-Tick helps you create branches and commits for a few ticket systems.
 
 Currently, we support:
 
-- GitHub
-- GitLab
-- Jira
-- Pivotal Tracker
-- Trello
+- [GitHub](https://github.com/)
+- [GitLab](https://gitlab.com/)
+- [Jira](https://www.atlassian.com/software/jira)
+- [Ora](https://ora.pm/)
+- [Pivotal Tracker](https://www.pivotaltracker.com/)
+- [Trello](https://trello.com/)
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "2.0.1",
+  "version": "2.1.0",
   "name": "tickety-tick",
   "description": "A browser extension that helps you to create commit messages and branch names from story trackers.",
   "author": "Bodo Tasche <bodo@bitcrowd.net>",

--- a/spec/adapters/ora-spec.js
+++ b/spec/adapters/ora-spec.js
@@ -1,0 +1,85 @@
+import { JSDOM } from 'jsdom';
+
+import adapter from '../../src/common/adapters/ora';
+
+function task({ id, title, type }) {
+  return `
+    <div class="single-task-modal" id="task-modal">
+      <div class="sub-stats-container">
+        <!-- … -->
+      </div>
+      <div class="header">
+        <form data-ng-submit="updateTaskTitle(currentTask,taskTitle)">
+          <textarea id="task-title">${title}</textarea>
+        </form>
+      </div>
+      <div class="under-title-container">
+        <div data-ng-hide="::!editRights" class="submenu">
+          <div data-ng-if="features.visible_id" class="task-id">
+            <span>#${id}</span>
+          </div>
+          <div data-ng-if="features['task_types']" data-is-open="taskTypesPopover.open">
+            <div class="text dropdown-toggle" aria-expanded="false">
+              <span class="hide-mobile capitalize-first-letter truncate70">${type}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="content">
+        <div class="extras">
+          <div>
+            <div data-ng-if="description && !taskDescriptionEdit">
+              <p>A description paragraph</p>
+              <ul>
+                <li>list item 0</li>
+                <li>list item 1 with a mention <a data-uib-tooltip="Search for Regulations" class="mention">#42</a>)</li>
+                <li>list item 2</li>
+              </ul>
+              <p>…and more text</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+describe('ora adapter', () => {
+  const loc = { host: 'ora.pm', pathname: '/project/53123/kanban/task/641617' };
+
+  function doc(body) {
+    const { window } = new JSDOM(`<html><body>${body}</body></html>`);
+    return window.document;
+  }
+
+  it('returns null if it is on a different page', () => {
+    adapter.inspect({ host: 'github.com' }, null, (err, res) => {
+      expect(err).toBe(null);
+      expect(res).toBe(null);
+    });
+  });
+
+  it('extracts feature tickets', () => {
+    const ticket = { id: 'ORA12', title: 'Random Ora task title', type: 'feature' };
+    adapter.inspect(loc, doc(task(ticket)), (err, res) => {
+      expect(err).toBe(null);
+      expect(res).toEqual([ticket]);
+    });
+  });
+
+  it('extracts chore tickets', () => {
+    const ticket = { id: 'ORA12', title: 'Random Ora task title', type: 'chore' };
+    adapter.inspect(loc, doc(task(ticket)), (err, res) => {
+      expect(err).toBe(null);
+      expect(res).toEqual([ticket]);
+    });
+  });
+
+  it('extracts bug tickets', () => {
+    const ticket = { id: 'ORA12', title: 'Random Ora task title', type: 'bug' };
+    adapter.inspect(loc, doc(task(ticket)), (err, res) => {
+      expect(err).toBe(null);
+      expect(res).toEqual([ticket]);
+    });
+  });
+});

--- a/src/common/adapters/jira.js
+++ b/src/common/adapters/jira.js
@@ -48,7 +48,7 @@ const adapter = {
     }
 
     if ($has('.ghx-columns .ghx-issue.ghx-selected', doc)) {
-      // Board view, when a ticket is opened in a modal window
+      // board view, when a ticket is opened in a modal window
       const issue = $find('.ghx-columns .ghx-issue.ghx-selected', doc);
       const id = $attr('.ghx-key', issue, 'aria-label');
       const title = $text('.ghx-summary', issue);

--- a/src/common/adapters/ora.js
+++ b/src/common/adapters/ora.js
@@ -1,0 +1,28 @@
+import {
+  $find,
+  $has,
+  $text,
+} from './helpers';
+
+function identifier(value) {
+  if (typeof value === 'string') return value.replace(/^#/, '');
+  return null;
+}
+
+const adapter = {
+  inspect(loc, doc, fn) {
+    if (loc.host !== 'ora.pm') return fn(null, null);
+
+    if ($has('#task-modal.single-task-modal', doc)) {
+      const task = $find('#task-modal.single-task-modal', doc);
+      const id = identifier($text('.task-id', task));
+      const title = $text('#task-title', task);
+      const type = $text('[data-ng-if="features[\'task_types\']"]', task) || 'feature';
+      return fn(null, [{ id, title, type }]);
+    }
+
+    return fn(null, null);
+  },
+};
+
+export default adapter;

--- a/src/common/search.js
+++ b/src/common/search.js
@@ -1,10 +1,11 @@
 import GitHub from './adapters/github';
 import GitLab from './adapters/gitlab';
 import Jira from './adapters/jira';
+import Ora from './adapters/ora';
 import Pivotal from './adapters/pivotal';
 import Trello from './adapters/trello';
 
-const stdadapters = [GitHub, GitLab, Jira, Pivotal, Trello];
+const stdadapters = [GitHub, GitLab, Jira, Ora, Pivotal, Trello];
 
 function search(adapters, loc, doc, fn) {
   let pending = adapters.length;


### PR DESCRIPTION
Add support for Ora. More specifically, allow Tickety-Tick to pick up information from opened tasks (information is extracted for single tasks that are opened in a model when clicking on them).

Addresses #110.