### PR TITLE
Update adapter code

### DIFF
--- a/src/common/adapters/github.js
+++ b/src/common/adapters/github.js
@@ -5,49 +5,47 @@ import {
   $value,
 } from './helpers';
 
-const adapter = {
-  inspect(loc, doc, fn) {
-    if ($has('.issues-listing .js-issue-row.selected', doc)) {
-      const issues = $all('.issues-listing .js-issue-row.selected', doc);
+async function scan(loc, doc) {
+  if ($has('.issues-listing .js-issue-row.selected', doc)) {
+    const issues = $all('.issues-listing .js-issue-row.selected', doc);
 
-      const tickets = issues.map((issue) => {
-        const id = $value('input.js-issues-list-check', issue);
-        const title = $text('a.js-navigation-open', issue);
-        const labels = $all('.labels .label', issue);
-        const type = labels.some(l => /bug/i.test(l.textContent)) ? 'bug' : 'feature';
+    const tickets = issues.map((issue) => {
+      const id = $value('input.js-issues-list-check', issue);
+      const title = $text('a.js-navigation-open', issue);
+      const labels = $all('.labels .label', issue);
+      const type = labels.some(l => /bug/i.test(l.textContent)) ? 'bug' : 'feature';
 
-        return { id, title, type };
-      });
+      return { id, title, type };
+    });
 
-      return fn(null, tickets);
-    }
+    return tickets;
+  }
 
-    if ($has('.issues-listing .gh-header-number', doc)) {
-      const id = $text('.gh-header-number', doc).replace(/^#/, '');
-      const title = $text('.js-issue-title', doc);
-      const type = $has('.sidebar-labels .label[title="bug"]', doc) ? 'bug' : 'feature';
-      const tickets = [{ id, title, type }];
-      return fn(null, tickets);
-    }
+  if ($has('.issues-listing .gh-header-number', doc)) {
+    const id = $text('.gh-header-number', doc).replace(/^#/, '');
+    const title = $text('.js-issue-title', doc);
+    const type = $has('.sidebar-labels .label[title="bug"]', doc) ? 'bug' : 'feature';
+    const tickets = [{ id, title, type }];
+    return tickets;
+  }
 
-    // github project
-    if ($has('.project-columns .project-card', doc)) {
-      const openProjectCardSelector = '.project-columns .project-card[data-card-state=\'["open"]\']';
-      const projectCards = $all(openProjectCardSelector, doc);
+  // github project
+  if ($has('.project-columns .project-card', doc)) {
+    const openProjectCardSelector = '.project-columns .project-card[data-card-state=\'["open"]\']';
+    const projectCards = $all(openProjectCardSelector, doc);
 
-      const tickets = projectCards.map((card) => {
-        const id = JSON.parse(card.dataset.cardTitle).slice(-2, -1)[0];
-        const title = $text('a.h5', card);
-        const type = JSON.parse(card.dataset.cardLabel).includes('bug') ? 'bug' : 'feature';
+    const tickets = projectCards.map((card) => {
+      const id = JSON.parse(card.dataset.cardTitle).slice(-2, -1)[0];
+      const title = $text('a.h5', card);
+      const type = JSON.parse(card.dataset.cardLabel).includes('bug') ? 'bug' : 'feature';
 
-        return { id, title, type };
-      });
+      return { id, title, type };
+    });
 
-      return fn(null, tickets);
-    }
+    return tickets;
+  }
 
-    return fn(null, null);
-  },
-};
+  return null;
+}
 
-export default adapter;
+export default scan;

--- a/src/common/adapters/github.test.js
+++ b/src/common/adapters/github.test.js
@@ -1,6 +1,6 @@
 import { JSDOM } from 'jsdom';
 
-import adapter from './github';
+import scan from './github';
 
 const ISSUEPAGE = `
   <div class="issues-listing">
@@ -75,45 +75,31 @@ describe('github adapter', () => {
     return window.document;
   }
 
-  it('returns null if it is on a different page', () => {
-    adapter.inspect(null, dom(), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toBe(null);
-    });
+  it('returns null if it is on a different page', async () => {
+    const result = await scan(null, dom());
+    expect(result).toBe(null);
   });
 
-  it('extracts tickets from issue pages', () => {
-    const expected = [{ id: '12', title: 'A Random GitHub Issue', type: 'feature' }];
-    adapter.inspect(null, dom(ISSUEPAGE), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('extracts tickets from issue pages', async () => {
+    const result = await scan(null, dom(ISSUEPAGE));
+    expect(result).toEqual([{ id: '12', title: 'A Random GitHub Issue', type: 'feature' }]);
   });
 
-  it('recognizes issues labelled as bugs', () => {
-    const expected = [{ id: '12', title: 'A Random GitHub Issue', type: 'bug' }];
-    adapter.inspect(null, dom(BUGPAGE), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('recognizes issues labelled as bugs', async () => {
+    const result = await scan(null, dom(BUGPAGE));
+    expect(result).toEqual([{ id: '12', title: 'A Random GitHub Issue', type: 'bug' }]);
   });
 
-  it('extracts tickets from issues index pages', () => {
-    const expected = [{ id: '12', title: 'A Selected GitHub Issue', type: 'bug' }];
-    adapter.inspect(null, dom(INDEXPAGE), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('extracts tickets from issues index pages', async () => {
+    const result = await scan(null, dom(INDEXPAGE));
+    expect(result).toEqual([{ id: '12', title: 'A Selected GitHub Issue', type: 'bug' }]);
   });
 
-  it('extracts tickets from project pages', () => {
-    const expected = [
+  it('extracts tickets from project pages', async () => {
+    const result = await scan(null, dom(PROJECTPAGE));
+    expect(result).toEqual([
       { id: '42', title: 'An Example Feature Ticket', type: 'feature' },
       { id: '43', title: 'An Example Bug Ticket', type: 'bug' },
-    ];
-    adapter.inspect(null, dom(PROJECTPAGE), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+    ]);
   });
 });

--- a/src/common/adapters/gitlab.js
+++ b/src/common/adapters/gitlab.js
@@ -1,20 +1,19 @@
 import { $has, $text } from './helpers';
 
-const adapter = {
-  inspect(loc, doc, fn) {
-    if (doc.body.dataset.page === 'projects:issues:show') {
-      const initialDataEl = doc.getElementById('js-issuable-app-initial-data');
-      const initialData = JSON.parse(initialDataEl.innerHTML.replace(/&quot;/g, '"'));
+async function scan(loc, doc) {
+  if (doc.body.dataset.page === 'projects:issues:show') {
+    const initialDataEl = doc.getElementById('js-issuable-app-initial-data');
+    const initialData = JSON.parse(initialDataEl.innerHTML.replace(/&quot;/g, '"'));
 
-      const id = initialData.issuableRef.match(/#(\d+)/)[1];
-      const title = $text('.issue-details .title', doc);
-      const type = $has('.labels [data-original-title="bug"]', doc) ? 'bug' : 'feature';
-      const tickets = [{ id, title, type }];
-      return fn(null, tickets);
-    }
+    const id = initialData.issuableRef.match(/#(\d+)/)[1];
+    const title = $text('.issue-details .title', doc);
+    const type = $has('.labels [data-original-title="bug"]', doc) ? 'bug' : 'feature';
+    const tickets = [{ id, title, type }];
 
-    return fn(null, null);
-  },
-};
+    return tickets;
+  }
 
-export default adapter;
+  return null;
+}
+
+export default scan;

--- a/src/common/adapters/gitlab.test.js
+++ b/src/common/adapters/gitlab.test.js
@@ -1,6 +1,6 @@
 import { JSDOM } from 'jsdom';
 
-import adapter from './gitlab';
+import scan from './gitlab';
 
 const ISSUEPAGE = `
   <div class="content">
@@ -44,26 +44,18 @@ describe('gitlab adapter', () => {
     return window.document;
   }
 
-  it('returns null if it is on a different page', () => {
-    adapter.inspect(null, dom(), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toBe(null);
-    });
+  it('returns null if it is on a different page', async () => {
+    const result = await scan(null, dom());
+    expect(result).toBe(null);
   });
 
-  it('extracts tickets from issue pages', () => {
-    const expected = [{ id: '22578', title: 'A Random GitLab Issue', type: 'feature' }];
-    adapter.inspect(null, dom(ISSUEPAGE, 'projects:issues:show'), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('extracts tickets from issue pages', async () => {
+    const result = await scan(null, dom(ISSUEPAGE, 'projects:issues:show'));
+    expect(result).toEqual([{ id: '22578', title: 'A Random GitLab Issue', type: 'feature' }]);
   });
 
-  it('recognizes issues labelled as bugs', () => {
-    const expected = [{ id: '22578', title: 'A Random GitLab Issue', type: 'bug' }];
-    adapter.inspect(null, dom(BUGPAGE, 'projects:issues:show'), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('recognizes issues labelled as bugs', async () => {
+    const result = await scan(null, dom(BUGPAGE, 'projects:issues:show'));
+    expect(result).toEqual([{ id: '22578', title: 'A Random GitLab Issue', type: 'bug' }]);
   });
 });

--- a/src/common/adapters/jira.js
+++ b/src/common/adapters/jira.js
@@ -22,42 +22,40 @@ const ticketPageTitle = (issue) => {
   return $text('#summary-val', issue);
 };
 
-const adapter = {
-  inspect(loc, doc, fn) {
-    if (doc.body.id !== 'jira') return fn(null, null);
+async function scan(loc, doc) {
+  if (doc.body.id !== 'jira') return null;
 
-    if ($has('.ghx-backlog-column .ghx-backlog-card.ghx-selected', doc)) {
-      // ticket list with backlog and sprints
-      const issueCssPath = '.ghx-backlog-column .ghx-backlog-card.ghx-selected';
-      const issues = $all(issueCssPath, doc).map((issue) => {
-        const id = $text('.ghx-key', issue);
-        const title = $text('.ghx-summary .ghx-inner', issue);
-        const type = normalizeType($attr('.ghx-type', issue, 'title'));
-        return { id, title, type };
-      });
-      return fn(null, issues);
-    }
+  if ($has('.ghx-backlog-column .ghx-backlog-card.ghx-selected', doc)) {
+    // ticket list with backlog and sprints
+    const issueCssPath = '.ghx-backlog-column .ghx-backlog-card.ghx-selected';
+    const issues = $all(issueCssPath, doc).map((issue) => {
+      const id = $text('.ghx-key', issue);
+      const title = $text('.ghx-summary .ghx-inner', issue);
+      const type = normalizeType($attr('.ghx-type', issue, 'title'));
+      return { id, title, type };
+    });
+    return issues;
+  }
 
-    if ($has('#issue-content', doc)) {
-      // ticket show-page, when a single ticket is opened full-screen
-      const issue = $find('#issue-content', doc);
-      const id = $text('#key-val', issue);
-      const title = ticketPageTitle(issue);
-      const type = normalizeType($text('#type-val', issue));
-      return fn(null, [{ id, title, type }]);
-    }
+  if ($has('#issue-content', doc)) {
+    // ticket show-page, when a single ticket is opened full-screen
+    const issue = $find('#issue-content', doc);
+    const id = $text('#key-val', issue);
+    const title = ticketPageTitle(issue);
+    const type = normalizeType($text('#type-val', issue));
+    return [{ id, title, type }];
+  }
 
-    if ($has('.ghx-columns .ghx-issue.ghx-selected', doc)) {
-      // board view, when a ticket is opened in a modal window
-      const issue = $find('.ghx-columns .ghx-issue.ghx-selected', doc);
-      const id = $attr('.ghx-key', issue, 'aria-label');
-      const title = $text('.ghx-summary', issue);
-      const type = normalizeType($attr('.ghx-field-icon', issue, 'data-tooltip'));
-      return fn(null, [{ id, title, type }]);
-    }
+  if ($has('.ghx-columns .ghx-issue.ghx-selected', doc)) {
+    // board view, when a ticket is opened in a modal window
+    const issue = $find('.ghx-columns .ghx-issue.ghx-selected', doc);
+    const id = $attr('.ghx-key', issue, 'aria-label');
+    const title = $text('.ghx-summary', issue);
+    const type = normalizeType($attr('.ghx-field-icon', issue, 'data-tooltip'));
+    return [{ id, title, type }];
+  }
 
-    return fn(null, null);
-  },
-};
+  return null;
+}
 
-export default adapter;
+export default scan;

--- a/src/common/adapters/jira.test.js
+++ b/src/common/adapters/jira.test.js
@@ -1,6 +1,6 @@
 import { JSDOM } from 'jsdom';
 
-import adapter from './jira';
+import scan from './jira';
 
 // parts of the dom of the jira backlog issue-list
 // contains two tickets - one of them being selected
@@ -138,101 +138,66 @@ describe('jira adapter', () => {
     return window.document;
   }
 
-  it('returns null if it is on a different page', () => {
-    adapter.inspect(null, doc(STORYPAGE, 'foo'), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toBe(null);
-    });
+  it('returns null if it is on a different page', async () => {
+    const result = await scan(null, doc(STORYPAGE, 'foo'));
+    expect(result).toBe(null);
   });
 
-  it('extracts story tickets from a ticket page', () => {
-    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Issue', type: 'feature' }];
-    adapter.inspect(null, doc(STORYPAGE), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('extracts story tickets from a ticket page', async () => {
+    const result = await scan(null, doc(STORYPAGE));
+    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Issue', type: 'feature' }]);
   });
 
-  it('extracts story tickets from a ticket page even when the title is being edited', () => {
-    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Issue', type: 'feature' }];
-    adapter.inspect(null, doc(STORYPAGE_TITLE_EDITED), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('extracts story tickets from a ticket page even when the title is being edited', async () => {
+    const result = await scan(null, doc(STORYPAGE_TITLE_EDITED));
+    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Issue', type: 'feature' }]);
   });
 
-  it('extracts bug tickets from a ticket page', () => {
-    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Issue', type: 'bug' }];
-    adapter.inspect(null, doc(BUGPAGE), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('extracts bug tickets from a ticket page', async () => {
+    const result = await scan(null, doc(BUGPAGE));
+    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Issue', type: 'bug' }]);
   });
 
-  it('extracts chore tickets from a ticket page', () => {
-    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Issue', type: 'chore' }];
-    adapter.inspect(null, doc(CHOREPAGE), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('extracts chore tickets from a ticket page', async () => {
+    const result = await scan(null, doc(CHOREPAGE));
+    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Issue', type: 'chore' }]);
   });
 
-  it('extracts tickets from the backlog', () => {
-    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'feature' }];
-    adapter.inspect(null, doc(BACKLOG), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('extracts tickets from the backlog', async () => {
+    const result = await scan(null, doc(BACKLOG));
+    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'feature' }]);
   });
 
-  it('extracts bug tickets from the backlog', () => {
-    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'bug' }];
-    adapter.inspect(null, doc(BUG_BACKLOG), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('extracts bug tickets from the backlog', async () => {
+    const result = await scan(null, doc(BUG_BACKLOG));
+    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'bug' }]);
   });
 
-  it('extracts chore tickets from the backlog', () => {
-    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'chore' }];
-    adapter.inspect(null, doc(CHORE_BACKLOG), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('extracts chore tickets from the backlog', async () => {
+    const result = await scan(null, doc(CHORE_BACKLOG));
+    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'chore' }]);
   });
 
-  it('extracts tickets from the backlog when multiple tickets are selected', () => {
-    const expected = [
+  it('extracts tickets from the backlog when multiple tickets are selected', async () => {
+    const result = await scan(null, doc(BACKLOG_TWO_TICKETS_SELECTED));
+    expect(result).toEqual([
       { id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'feature' },
       { id: 'UXPL-47', title: 'A Random JIRA Bug Issue', type: 'bug' },
-    ];
-    adapter.inspect(null, doc(BACKLOG_TWO_TICKETS_SELECTED), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+    ]);
   });
 
-  it('extracts selected tickets from the board', () => {
-    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Board Issue', type: 'feature' }];
-    adapter.inspect(null, doc(BOARD_STORY), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('extracts selected tickets from the board', async () => {
+    const result = await scan(null, doc(BOARD_STORY));
+    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Board Issue', type: 'feature' }]);
   });
 
-  it('extracts selected bug tickets from the board', () => {
-    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Board Issue', type: 'bug' }];
-    adapter.inspect(null, doc(BOARD_BUG), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('extracts selected bug tickets from the board', async () => {
+    const result = await scan(null, doc(BOARD_BUG));
+    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Board Issue', type: 'bug' }]);
   });
 
-  it('extracts selected chore tickets from the board', () => {
-    const expected = [{ id: 'UXPL-39', title: 'A Random JIRA Board Issue', type: 'chore' }];
-    adapter.inspect(null, doc(BOARD_CHORE), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('extracts selected chore tickets from the board', async () => {
+    const result = await scan(null, doc(BOARD_CHORE));
+    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Board Issue', type: 'chore' }]);
   });
 });

--- a/src/common/adapters/ora.js
+++ b/src/common/adapters/ora.js
@@ -9,20 +9,18 @@ function identifier(value) {
   return null;
 }
 
-const adapter = {
-  inspect(loc, doc, fn) {
-    if (loc.host !== 'ora.pm') return fn(null, null);
+async function scan(loc, doc) {
+  if (loc.host !== 'ora.pm') return null;
 
-    if ($has('#task-modal.single-task-modal', doc)) {
-      const task = $find('#task-modal.single-task-modal', doc);
-      const id = identifier($text('.task-id', task));
-      const title = $text('#task-title', task);
-      const type = $text('[data-ng-if="features[\'task_types\']"]', task) || 'feature';
-      return fn(null, [{ id, title, type }]);
-    }
+  if ($has('#task-modal.single-task-modal', doc)) {
+    const task = $find('#task-modal.single-task-modal', doc);
+    const id = identifier($text('.task-id', task));
+    const title = $text('#task-title', task);
+    const type = $text('[data-ng-if="features[\'task_types\']"]', task) || 'feature';
+    return [{ id, title, type }];
+  }
 
-    return fn(null, null);
-  },
-};
+  return null;
+}
 
-export default adapter;
+export default scan;

--- a/src/common/adapters/ora.test.js
+++ b/src/common/adapters/ora.test.js
@@ -1,6 +1,6 @@
 import { JSDOM } from 'jsdom';
 
-import adapter from './ora';
+import scan from './ora';
 
 function task({ id, title, type }) {
   return `
@@ -52,34 +52,26 @@ describe('ora adapter', () => {
     return window.document;
   }
 
-  it('returns null if it is on a different page', () => {
-    adapter.inspect({ host: 'github.com' }, null, (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toBe(null);
-    });
+  it('returns null if it is on a different page', async () => {
+    const result = await scan({ host: 'github.com' }, null);
+    expect(result).toBe(null);
   });
 
-  it('extracts feature tickets', () => {
+  it('extracts feature tickets', async () => {
     const ticket = { id: 'ORA12', title: 'Random Ora task title', type: 'feature' };
-    adapter.inspect(loc, doc(task(ticket)), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual([ticket]);
-    });
+    const result = await scan(loc, doc(task(ticket)));
+    expect(result).toEqual([ticket]);
   });
 
-  it('extracts chore tickets', () => {
+  it('extracts chore tickets', async () => {
     const ticket = { id: 'ORA12', title: 'Random Ora task title', type: 'chore' };
-    adapter.inspect(loc, doc(task(ticket)), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual([ticket]);
-    });
+    const result = await scan(loc, doc(task(ticket)));
+    expect(result).toEqual([ticket]);
   });
 
-  it('extracts bug tickets', () => {
+  it('extracts bug tickets', async () => {
     const ticket = { id: 'ORA12', title: 'Random Ora task title', type: 'bug' };
-    adapter.inspect(loc, doc(task(ticket)), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual([ticket]);
-    });
+    const result = await scan(loc, doc(task(ticket)));
+    expect(result).toEqual([ticket]);
   });
 });

--- a/src/common/adapters/pivotal.js
+++ b/src/common/adapters/pivotal.js
@@ -25,33 +25,31 @@ function multiple(elements, collapsed) {
   });
 }
 
-const adapter = {
-  inspect(loc, doc, fn) {
-    if (doc.body.id !== 'tracker') return fn(null, null);
+async function scan(loc, doc) {
+  if (doc.body.id !== 'tracker') return null;
 
-    if ($has('div.story .selector.selected', doc)) { // selected stories
-      const selection = $all('div.story .selector.selected', doc).map(e => $closest('.story', e));
-      const tickets = multiple(selection, true);
-      return fn(null, tickets);
-    }
+  if ($has('div.story .selector.selected', doc)) { // selected stories
+    const selection = $all('div.story .selector.selected', doc).map(e => $closest('.story', e));
+    const tickets = multiple(selection, true);
+    return tickets;
+  }
 
-    if ($has('div.story .details', doc)) { // opened stories
-      const opened = $all('div.story .details', doc).map(e => $closest('.story', e));
-      const tickets = multiple(opened, false);
-      return fn(null, tickets);
-    }
+  if ($has('div.story .details', doc)) { // opened stories
+    const opened = $all('div.story .details', doc).map(e => $closest('.story', e));
+    const tickets = multiple(opened, false);
+    return tickets;
+  }
 
-    if ($has('.story.maximized', doc)) { // single story in separate tab
-      const story = $find('.story.maximized', doc);
-      const id = $value('aside input.id', story).replace(/^#/, '');
-      const title = $text('.editor.name', story);
-      const type = cls(story);
-      const tickets = [{ id, title, type }];
-      return fn(null, tickets);
-    }
+  if ($has('.story.maximized', doc)) { // single story in separate tab
+    const story = $find('.story.maximized', doc);
+    const id = $value('aside input.id', story).replace(/^#/, '');
+    const title = $text('.editor.name', story);
+    const type = cls(story);
+    const tickets = [{ id, title, type }];
+    return tickets;
+  }
 
-    return fn(null, null);
-  },
-};
+  return null;
+}
 
-export default adapter;
+export default scan;

--- a/src/common/adapters/pivotal.test.js
+++ b/src/common/adapters/pivotal.test.js
@@ -1,6 +1,6 @@
 import { JSDOM } from 'jsdom';
 
-import adapter from './pivotal';
+import scan from './pivotal';
 
 function selected({ id, title, type }) {
   return `
@@ -58,38 +58,30 @@ describe('pivotal adapter', () => {
     return window.document;
   }
 
-  it('returns null if it is on a different page', () => {
+  it('returns null if it is on a different page', async () => {
     const doc = dom(selected({ id: '1', title: 'Foo' }), 'trello');
-    adapter.inspect(null, doc, (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toBe(null);
-    });
+    const result = await scan(null, doc);
+    expect(result).toBe(null);
   });
 
-  it('extracts tickets from selected stories', () => {
+  it('extracts tickets from selected stories', async () => {
     const expected = [{ id: '1231244', title: 'A Selected Pivotal Story', type: 'feature' }];
     const doc = dom(expected.map(selected).join(''));
-    adapter.inspect(null, doc, (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+    const result = await scan(null, doc);
+    expect(result).toEqual(expected);
   });
 
-  it('extracts tickets from opened stories', () => {
+  it('extracts tickets from opened stories', async () => {
     const expected = [{ id: '1231245', title: 'An Opened Pivotal Story', type: 'bug' }];
     const doc = dom(expected.map(opened).join(''));
-    adapter.inspect(null, doc, (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+    const result = await scan(null, doc);
+    expect(result).toEqual(expected);
   });
 
-  it('extracts tickets from maximized stories', () => {
+  it('extracts tickets from maximized stories', async () => {
     const expected = [{ id: '1231246', title: 'A Maximized Pivotal Story', type: 'chore' }];
     const doc = dom(expected.map(maximized).join(''));
-    adapter.inspect(null, doc, (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+    const result = await scan(null, doc);
+    expect(result).toEqual(expected);
   });
 });

--- a/src/common/adapters/trello.js
+++ b/src/common/adapters/trello.js
@@ -1,18 +1,16 @@
 import { $has, $text } from './helpers';
 
-const adapter = {
-  inspect(loc, doc, fn) {
-    if (loc.host !== 'trello.com') return fn(null, null);
-    if (!$has('.card-detail-window', doc)) return fn(null, null);
+async function scan(loc, doc) {
+  if (loc.host !== 'trello.com') return null;
+  if (!$has('.card-detail-window', doc)) return null;
 
-    const id = loc.pathname.match(/\/([\d]+)-[^/]+$/)[1];
-    const title = $text('.card-detail-title-assist', doc);
-    const type = 'feature';
+  const id = loc.pathname.match(/\/([\d]+)-[^/]+$/)[1];
+  const title = $text('.card-detail-title-assist', doc);
+  const type = 'feature';
 
-    const tickets = [{ id, title, type }];
+  const tickets = [{ id, title, type }];
 
-    return fn(null, tickets);
-  },
-};
+  return tickets;
+}
 
-export default adapter;
+export default scan;

--- a/src/common/adapters/trello.test.js
+++ b/src/common/adapters/trello.test.js
@@ -1,6 +1,6 @@
 import { JSDOM } from 'jsdom';
 
-import adapter from './trello';
+import scan from './trello';
 
 const CARD = `
   <div class="card-detail-window">
@@ -16,18 +16,13 @@ describe('trello adapter', () => {
     return window.document;
   }
 
-  it('returns null if it is on a different page', () => {
-    adapter.inspect({ host: 'other.com' }, doc(CARD), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toBe(null);
-    });
+  it('returns null if it is on a different page', async () => {
+    const result = await scan({ host: 'other.com' }, doc(CARD));
+    expect(result).toBe(null);
   });
 
-  it('extracts tickets from trello cards', () => {
-    const expected = [{ id: '89', title: 'A Trello Card', type: 'feature' }];
-    adapter.inspect(loc, doc(CARD), (err, res) => {
-      expect(err).toBe(null);
-      expect(res).toEqual(expected);
-    });
+  it('extracts tickets from trello cards', async () => {
+    const result = await scan(loc, doc(CARD));
+    expect(result).toEqual([{ id: '89', title: 'A Trello Card', type: 'feature' }]);
   });
 });

--- a/src/common/popup/render.jsx
+++ b/src/common/popup/render.jsx
@@ -1,5 +1,3 @@
-/* eslint-env browser */
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { MemoryRouter as Router, Route } from 'react-router';

--- a/src/common/search.js
+++ b/src/common/search.js
@@ -8,24 +8,9 @@ import Trello from './adapters/trello';
 export const stdadapters = [GitHub, GitLab, Jira, Ora, Pivotal, Trello];
 
 export function search(adapters, loc, doc, fn) {
-  let pending = adapters.length;
-  const results = [];
-
-  function done() {
-    const res = results.find(e => (e !== null));
-    fn(res || null);
-  }
-
-  adapters.forEach((adapter, i) => {
-    adapter.inspect(loc, doc, (err, res) => {
-      if (err) console.error(err); // eslint-disable-line no-console
-
-      results[i] = err ? null : res;
-      pending -= 1;
-
-      if (pending === 0) done();
-    });
-  });
+  Promise.all(adapters.map(scan => scan(loc, doc)))
+    .then(results => results.find(e => (e !== null)))
+    .then(result => fn(result || null));
 }
 
 export default search.bind(null, stdadapters);

--- a/src/common/search.js
+++ b/src/common/search.js
@@ -7,10 +7,9 @@ import Trello from './adapters/trello';
 
 export const stdadapters = [GitHub, GitLab, Jira, Ora, Pivotal, Trello];
 
-export function search(adapters, loc, doc, fn) {
-  Promise.all(adapters.map(scan => scan(loc, doc)))
-    .then(results => results.find(e => (e !== null)))
-    .then(result => fn(result || null));
+export async function search(adapters, loc, doc) {
+  const results = await Promise.all(adapters.map(scan => scan(loc, doc)));
+  return results.find(e => (e !== null)) || null;
 }
 
 export default search.bind(null, stdadapters);

--- a/src/common/search.test.js
+++ b/src/common/search.test.js
@@ -11,34 +11,26 @@ describe('ticket search', () => {
   const doc = { title: 'dummy document' };
   const loc = { host: 'dummy.org' };
 
-  it('feeds the location and document to every adapter', (done) => {
+  it('feeds the location and document to every adapter', async () => {
     const adapters = mocks([null, null]);
 
-    search(adapters, loc, doc, () => {
-      adapters.forEach((scan) => {
-        expect(scan).toHaveBeenCalledWith(loc, doc);
-      });
+    await search(adapters, loc, doc);
 
-      done();
+    adapters.forEach((scan) => {
+      expect(scan).toHaveBeenCalledWith(loc, doc);
     });
   });
 
-  it('invokes the callback with the first non-null adapter result', (done) => {
+  it('invokes the callback with the first non-null adapter result', async () => {
     const result = [{ id: '1', title: 'true story' }];
     const adapters = mocks([null, result]);
 
-    search(adapters, loc, doc, (res) => {
-      expect(res).toBe(result);
-      done();
-    });
+    await expect(search(adapters, loc, doc)).resolves.toBe(result);
   });
 
-  it('invokes the callback with null when no adapter created any results', (done) => {
+  it('invokes the callback with null when no adapter created any results', async () => {
     const adapters = mocks([null, undefined]);
 
-    search(adapters, loc, doc, (res) => {
-      expect(res).toBe(null);
-      done();
-    });
+    await expect(search(adapters, loc, doc)).resolves.toBe(null);
   });
 });

--- a/src/common/search.test.js
+++ b/src/common/search.test.js
@@ -3,8 +3,7 @@ import { search } from './search';
 describe('ticket search', () => {
   function mocks(results) {
     return results.map((result) => {
-      const adapter = { inspect: jest.fn() };
-      adapter.inspect.mockImplementation((l, d, fn) => { fn(null, result); });
+      const adapter = jest.fn().mockResolvedValue(result);
       return adapter;
     });
   }
@@ -16,8 +15,8 @@ describe('ticket search', () => {
     const adapters = mocks([null, null]);
 
     search(adapters, loc, doc, () => {
-      adapters.forEach((adapter) => {
-        expect(adapter.inspect).toHaveBeenCalledWith(loc, doc, expect.any(Function));
+      adapters.forEach((scan) => {
+        expect(scan).toHaveBeenCalledWith(loc, doc);
       });
 
       done();

--- a/src/safari-extension/content.js
+++ b/src/safari-extension/content.js
@@ -1,4 +1,3 @@
-/* eslint-env browser */
 /* global safari */
 
 import stdsearch from '../common/search';
@@ -6,7 +5,7 @@ import stdsearch from '../common/search';
 function onMessage(event) {
   if (window.top === window) {
     if (event.name === 'get-tickets') {
-      stdsearch(window.location, document, (tickets) => {
+      stdsearch(window.location, document).then((tickets) => {
         safari.self.tab.dispatchMessage('tickets', tickets);
       });
     }

--- a/src/safari-extension/popup/popup.js
+++ b/src/safari-extension/popup/popup.js
@@ -1,4 +1,3 @@
-/* eslint-env browser */
 /* global safari */
 
 import render from '../../common/popup/render';

--- a/src/web-extension/background.js
+++ b/src/web-extension/background.js
@@ -1,10 +1,9 @@
-/* eslint-env browser */
 /* global chrome */
 
 function getTickets(callback) {
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    chrome.tabs.sendMessage(tabs[0].id, { tickets: true }, (newTickets) => {
-      callback(newTickets);
+  chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
+    chrome.tabs.sendMessage(tab.id, { tickets: true }, (tickets) => {
+      callback(tickets);
     });
   });
 }

--- a/src/web-extension/content.js
+++ b/src/web-extension/content.js
@@ -1,4 +1,3 @@
-/* eslint-env browser */
 /* global chrome */
 
 import stdsearch from '../common/search';
@@ -8,7 +7,15 @@ const { runtime } = chrome;
 if (window === window.top) {
   runtime.onMessage.addListener((req, sender, respond) => {
     if (req.tickets) {
-      stdsearch(window.location, document, respond);
+      // TODO: Figure out why the respond callback does not work when invoked asynchronously.
+      //
+      // In particular, when invoked from a resolved promise callback (`then`)
+      // or with a 0 timeout (`setTimeout`), respond does not do anything.
+      //
+      // Debugging into the callback internals shows that the `port` for communicating with
+      // between the background page and the content script is `null`.
+      //
+      stdsearch(window.location, document).then(respond);
     }
   });
 }

--- a/src/web-extension/content.js
+++ b/src/web-extension/content.js
@@ -7,15 +7,10 @@ const { runtime } = chrome;
 if (window === window.top) {
   runtime.onMessage.addListener((req, sender, respond) => {
     if (req.tickets) {
-      // TODO: Figure out why the respond callback does not work when invoked asynchronously.
-      //
-      // In particular, when invoked from a resolved promise callback (`then`)
-      // or with a 0 timeout (`setTimeout`), respond does not do anything.
-      //
-      // Debugging into the callback internals shows that the `port` for communicating with
-      // between the background page and the content script is `null`.
-      //
       stdsearch(window.location, document).then(respond);
+      return true;
     }
+
+    return false;
   });
 }

--- a/src/web-extension/options/options.jsx
+++ b/src/web-extension/options/options.jsx
@@ -1,5 +1,3 @@
-/* eslint-env browser */
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/src/web-extension/popup/popup.js
+++ b/src/web-extension/popup/popup.js
@@ -1,4 +1,3 @@
-/* eslint-env browser */
 /* global chrome */
 
 import render from '../../common/popup/render';


### PR DESCRIPTION
**Description**

Make adapters async functions so they're more intuitive, e.g. with regard to fetching ticket info from a web API. Previously they used callback style with error and ticket arguments for the callback. However the error argument was never actually used/set.

Now, adapters should export an async `scan` function that receives the page `location` and `document` and returns an array of tickets.

Example: [github.js](https://github.com/bitcrowd/tickety-tick/blob/update-adapter-code/src/common/adapters/github.js)
Compared to the previous way of writing adapters: [github.js (old)](https://github.com/bitcrowd/tickety-tick/blob/871a8a34fb1581dbd579750fa57023be0888a2a8/src/common/adapters/github.js)

Hint: Enable "Hide whitespace changes" in the diff options 😉 

---

Intermediate issue (for the record only):

Both Chrome and Firefox seem to have issues with asynchronous code when communicating between different extension scripts. In particular, the content script is unable to send a response to the background page when sending from a promise/timeout callback ([see code comment](https://github.com/bitcrowd/tickety-tick/commit/ad6ea6b85699870070f23fd8268bc37a90cb3ac8#diff-92ed3a44e047c3ddece099f21d73b7c5R10)).

🤦‍♂️ 

This needs some investigation.

![debugging](https://user-images.githubusercontent.com/706519/50388136-d1f16580-0705-11e9-9f17-d048f2a1a7f3.png)

☝️ `port` is `null`