### PR TITLE
Use WebExtension polyfill to avoid browser compatibility issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "react-dom": "16.7.0",
     "react-router": "4.3.1",
     "react-router-dom": "4.3.1",
-    "speakingurl": "14.0.1"
+    "speakingurl": "14.0.1",
+    "webextension-polyfill": "^0.3.1"
   }
 }

--- a/src/web-extension/background.js
+++ b/src/web-extension/background.js
@@ -1,11 +1,9 @@
-/* global chrome */
+import browser from 'webextension-polyfill';
 
-function getTickets(callback) {
-  chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
-    chrome.tabs.sendMessage(tab.id, { tickets: true }, (tickets) => {
-      callback(tickets);
-    });
-  });
+async function getTickets() {
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+  const tickets = await browser.tabs.sendMessage(tab.id, { tickets: true });
+  return tickets;
 }
 
 window.getTickets = getTickets;

--- a/src/web-extension/content.js
+++ b/src/web-extension/content.js
@@ -1,11 +1,9 @@
-/* global chrome */
+import browser from 'webextension-polyfill';
 
 import stdsearch from '../common/search';
 
-const { runtime } = chrome;
-
 if (window === window.top) {
-  runtime.onMessage.addListener((req) => {
+  browser.runtime.onMessage.addListener((req) => {
     if (req.tickets) {
       return stdsearch(window.location, document);
     }

--- a/src/web-extension/content.js
+++ b/src/web-extension/content.js
@@ -5,10 +5,9 @@ import stdsearch from '../common/search';
 const { runtime } = chrome;
 
 if (window === window.top) {
-  runtime.onMessage.addListener((req, sender, respond) => {
+  runtime.onMessage.addListener((req) => {
     if (req.tickets) {
-      stdsearch(window.location, document).then(respond);
-      return true;
+      return stdsearch(window.location, document);
     }
 
     return false;

--- a/src/web-extension/options/components/form.jsx
+++ b/src/web-extension/options/components/form.jsx
@@ -23,7 +23,7 @@ class Form extends Component {
 
   componentDidMount() {
     const { store } = this.props;
-    store.get(null, this.handleLoaded);
+    store.get(null).then(this.handleLoaded);
   }
 
   handleLoaded(data) {
@@ -47,7 +47,7 @@ class Form extends Component {
     const templates = { branch, commit, command };
 
     this.setState(() => ({ loading: true }), () => {
-      store.set({ templates }, this.handleSaved);
+      store.set({ templates }).then(this.handleSaved);
     });
   }
 

--- a/src/web-extension/options/components/form.test.jsx
+++ b/src/web-extension/options/components/form.test.jsx
@@ -7,68 +7,73 @@ import TemplateInput from './template-input';
 import { defaults as fallbacks, helpers } from '../../../common/format';
 
 describe('form', () => {
-  function render(overrides) {
-    const store = { get: jest.fn(), set: jest.fn() };
+  function render(overrides, options = {}) {
+    const store = { get: jest.fn().mockResolvedValue({}), set: jest.fn().mockResolvedValue({}) };
     const defaults = { store };
 
     const props = { ...defaults, ...overrides };
-    const wrapper = shallow(<Form {...props} />);
-    const instance = wrapper.instance();
+    const wrapper = shallow(<Form {...props} />, options);
 
-    return { wrapper, instance, props };
+    return wrapper;
   }
 
   const inputs = wrapper => wrapper.find(TemplateInput);
   const input = (wrapper, name) => inputs(wrapper).find({ name });
   const value = (wrapper, name) => input(wrapper, name).prop('value');
 
-  const change = (wrapper, instance, name, val) => {
+  const change = (wrapper, name, val) => {
     const event = { target: { name, value: val } };
-    instance.handleChanged(event);
-    wrapper.update();
+    const field = wrapper.find(TemplateInput).find({ name });
+    field.simulate('change', event);
   };
 
   it('renders a template-input for the branch name format', () => {
-    const { wrapper, instance } = render({});
-    expect(input(wrapper, 'branch').props()).toEqual({
+    const wrapper = render({});
+    const field = input(wrapper, 'branch');
+
+    expect(field.props()).toEqual({
       label: 'Branch Name Format',
       id: 'branch-name-format',
       name: 'branch',
       value: '',
       fallback: fallbacks.branch,
       disabled: true,
-      onChange: instance.handleChanged,
+      onChange: expect.any(Function),
     });
   });
 
   it('renders a template-input for the commit message format', () => {
-    const { wrapper, instance } = render({});
-    expect(input(wrapper, 'commit').props()).toEqual({
+    const wrapper = render({});
+    const field = input(wrapper, 'commit');
+
+    expect(field.props()).toEqual({
       label: 'Commit Message Format',
       id: 'commit-message-format',
       name: 'commit',
       value: '',
       fallback: fallbacks.commit,
       disabled: true,
-      onChange: instance.handleChanged,
+      onChange: expect.any(Function),
     });
   });
 
   it('renders a template-input for the command format', () => {
-    const { wrapper, instance } = render({});
-    expect(input(wrapper, 'command').props()).toEqual({
+    const wrapper = render({});
+    const field = input(wrapper, 'command');
+
+    expect(field.props()).toEqual({
       label: 'Command Format',
       id: 'command-format',
       name: 'command',
       value: '',
       fallback: fallbacks.command,
       disabled: true,
-      onChange: instance.handleChanged,
+      onChange: expect.any(Function),
     });
   });
 
   it('renders the names of available template helpers', () => {
-    const { wrapper } = render({});
+    const wrapper = render({});
     const text = wrapper.text();
 
     Object.keys(helpers).forEach((name) => {
@@ -76,76 +81,77 @@ describe('form', () => {
     });
   });
 
-  it('loads stored templates on mount', () => {
+  it('loads stored templates on mount and updates the form inputs', async () => {
     const store = { get: jest.fn(), set: jest.fn() };
-    const data = { templates: { branch: 'a', commit: 'b', command: 'c' } };
-    store.get.mockImplementation((_, fn) => fn(data));
 
-    const { instance } = render({ store });
-    jest.spyOn(instance, 'handleLoaded');
+    let loaded;
 
-    instance.componentDidMount();
+    store.get.mockReturnValue(new Promise((resolve) => {
+      // Create a new async function that resolves the promise returned from
+      // calls to `store.get()` and returns a promise itself which we can wait
+      // on to ensure the store results have been handled.
+      loaded = async function load(data) { resolve(data); };
+    }));
 
-    expect(store.get).toHaveBeenCalledWith(null, instance.handleLoaded);
-    expect(instance.handleLoaded).toHaveBeenCalledWith(data);
-  });
+    const wrapper = render({ store });
 
-  it('updates the form inputs once templates are loaded', () => {
-    const { wrapper, instance } = render({});
-    const data = { templates: { branch: 'x', commit: 'y', command: 'z' } };
+    expect(store.get).toHaveBeenCalledWith(null);
+    expect(inputs(wrapper).every({ disabled: true })).toBe(true);
 
-    instance.handleLoaded(data);
-    wrapper.update();
+    await loaded({ templates: { branch: 'a', commit: 'b', command: 'c' } });
 
-    expect(value(wrapper, 'branch')).toBe('x');
-    expect(value(wrapper, 'commit')).toBe('y');
-    expect(value(wrapper, 'command')).toBe('z');
+    expect(value(wrapper, 'branch')).toBe('a');
+    expect(value(wrapper, 'commit')).toBe('b');
+    expect(value(wrapper, 'command')).toBe('c');
 
     expect(inputs(wrapper).every({ disabled: false })).toBe(true);
   });
 
   it('updates the form inputs on changes', () => {
-    const { wrapper, instance } = render({});
+    const wrapper = render({});
 
-    change(wrapper, instance, 'branch', 'branch++');
+    change(wrapper, 'branch', 'branch++');
     expect(value(wrapper, 'branch')).toBe('branch++');
 
-    change(wrapper, instance, 'commit', 'commit++');
+    change(wrapper, 'commit', 'commit++');
     expect(value(wrapper, 'commit')).toBe('commit++');
 
-    change(wrapper, instance, 'command', 'command++');
+    change(wrapper, 'command', 'command++');
     expect(value(wrapper, 'command')).toBe('command++');
   });
 
-  it('stores templates on submit', () => {
+  it('stores templates on submit and disables form elements while saving', async () => {
     const store = { get: jest.fn(), set: jest.fn() };
-    store.set.mockImplementation((_, fn) => fn());
 
-    const { wrapper, instance } = render({ store });
-    jest.spyOn(instance, 'handleSaved').mockReturnValue();
+    let saved;
 
-    change(wrapper, instance, 'branch', 'branch++');
-    change(wrapper, instance, 'commit', 'commit++');
-    change(wrapper, instance, 'command', 'command++');
+    const unchanged = { branch: 'branch', commit: 'commit', command: 'command' };
+    store.get.mockResolvedValue({ templates: unchanged });
+    store.set.mockReturnValue(new Promise((resolve) => {
+      // Create a new async function that resolves the promise returned from
+      // calls to `store.set()` and returns a promise itself which we can wait
+      // on to ensure data saving has been handled.
+      saved = async function save() { resolve(); };
+    }));
+
+    const wrapper = render({ store });
+
+    change(wrapper, 'branch', 'branch++');
+    change(wrapper, 'commit', 'commit++');
+    change(wrapper, 'command', 'command++');
 
     const event = { preventDefault: jest.fn() };
     wrapper.simulate('submit', event);
 
     expect(event.preventDefault).toHaveBeenCalled();
 
-    const templates = { branch: 'branch++', commit: 'commit++', command: 'command++' };
-    expect(store.set).toHaveBeenCalledWith({ templates }, instance.handleSaved);
+    const changed = { branch: 'branch++', commit: 'commit++', command: 'command++' };
+    expect(store.set).toHaveBeenCalledWith({ templates: changed });
+
     expect(wrapper.find('button[type="submit"]').prop('disabled')).toBe(true);
     expect(inputs(wrapper).every({ disabled: true })).toBe(true);
-    expect(instance.handleSaved).toHaveBeenCalled();
-  });
 
-  it('re-enables the form elements once templates are stored', () => {
-    const { wrapper, instance } = render({});
-
-    wrapper.simulate('submit', { preventDefault: () => {} });
-    instance.handleSaved();
-    wrapper.update();
+    await saved();
 
     expect(wrapper.find('button[type="submit"]').prop('disabled')).toBe(false);
     expect(inputs(wrapper).every({ disabled: false })).toBe(true);

--- a/src/web-extension/options/components/form.test.jsx
+++ b/src/web-extension/options/components/form.test.jsx
@@ -29,6 +29,8 @@ describe('form', () => {
 
   it('renders a template-input for the branch name format', () => {
     const wrapper = render({});
+    const instance = wrapper.instance();
+
     const field = input(wrapper, 'branch');
 
     expect(field.props()).toEqual({
@@ -38,12 +40,14 @@ describe('form', () => {
       value: '',
       fallback: fallbacks.branch,
       disabled: true,
-      onChange: expect.any(Function),
+      onChange: instance.handleChanged,
     });
   });
 
   it('renders a template-input for the commit message format', () => {
     const wrapper = render({});
+    const instance = wrapper.instance();
+
     const field = input(wrapper, 'commit');
 
     expect(field.props()).toEqual({
@@ -53,12 +57,14 @@ describe('form', () => {
       value: '',
       fallback: fallbacks.commit,
       disabled: true,
-      onChange: expect.any(Function),
+      onChange: instance.handleChanged,
     });
   });
 
   it('renders a template-input for the command format', () => {
     const wrapper = render({});
+    const instance = wrapper.instance();
+
     const field = input(wrapper, 'command');
 
     expect(field.props()).toEqual({
@@ -68,7 +74,7 @@ describe('form', () => {
       value: '',
       fallback: fallbacks.command,
       disabled: true,
-      onChange: expect.any(Function),
+      onChange: instance.handleChanged,
     });
   });
 

--- a/src/web-extension/options/components/template-input.test.jsx
+++ b/src/web-extension/options/components/template-input.test.jsx
@@ -18,18 +18,18 @@ describe('template-input', () => {
     const props = { ...defaults, ...overrides };
     const wrapper = shallow(<TemplateInput {...props} />);
 
-    return { wrapper, props };
+    return wrapper;
   }
 
   it('renders an input label', () => {
-    const { wrapper } = render({ id: 'id-1', label: 'Awesome Template Label' });
+    const wrapper = render({ id: 'id-1', label: 'Awesome Template Label' });
     const label = wrapper.find('label');
     expect(label.prop('htmlFor')).toBe('id-1');
     expect(label.text()).toBe('Awesome Template Label');
   });
 
   it('renders an input field', () => {
-    const { wrapper } = render({ id: 'id-2', name: 'name-2', value: 'vvv' });
+    const wrapper = render({ id: 'id-2', name: 'name-2', value: 'vvv' });
     const input = wrapper.find('input');
     expect(input.prop('id')).toBe('id-2');
     expect(input.prop('name')).toBe('name-2');
@@ -38,19 +38,19 @@ describe('template-input', () => {
 
   it('notifies about input changes', () => {
     const onChange = () => 'called on change';
-    const { wrapper } = render({ onChange });
+    const wrapper = render({ onChange });
     const input = wrapper.find('input');
     expect(input.prop('onChange')).toBe(onChange);
   });
 
   it('disables the input if requested', () => {
-    const { wrapper } = render({ disabled: true });
+    const wrapper = render({ disabled: true });
     const input = wrapper.find('input');
     expect(input.prop('disabled')).toBe(true);
   });
 
   it('renders the default value used as a fallback', () => {
-    const { wrapper } = render({ fallback: 'fbfbfb' });
+    const wrapper = render({ fallback: 'fbfbfb' });
     expect(wrapper.text()).toContain('fbfbfb');
   });
 });

--- a/src/web-extension/popup/popup.js
+++ b/src/web-extension/popup/popup.js
@@ -1,4 +1,4 @@
-/* global chrome */
+import browser from 'webextension-polyfill';
 
 import render from '../../common/popup/render';
 import enhance from '../../common/enhance';
@@ -6,8 +6,7 @@ import '../../common/popup/popup.scss';
 
 import store from '../store';
 
-const { extension } = chrome;
-const background = extension.getBackgroundPage();
+const background = browser.extension.getBackgroundPage();
 
 function pbcopy(text) {
   const input = document.createElement('textarea');
@@ -31,16 +30,15 @@ function openext() {
   return true;
 }
 
-function load() {
-  store.get(null, ({ templates }) => {
-    background.getTickets((tickets) => {
-      const result = tickets
-        ? tickets.map(enhance(templates))
-        : null;
+async function load() {
+  const { templates } = await store.get(null);
+  const tickets = await background.getTickets();
 
-      render(result, { grab, openext });
-    });
-  });
+  const result = tickets
+    ? tickets.map(enhance(templates))
+    : null;
+
+  render(result, { grab, openext });
 }
 
 window.onload = load;

--- a/src/web-extension/store.js
+++ b/src/web-extension/store.js
@@ -1,6 +1,6 @@
-/* global chrome */
+import browser from 'webextension-polyfill';
 
 // Store preferences in synced storage if available, use local as a fallback:
 // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/storage/sync
 // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/storage/local
-export default chrome.storage.sync || chrome.storage.local;
+export default browser.storage.sync || browser.storage.local;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11189,6 +11189,11 @@ web-ext@2.9.3:
     yargs "6.6.0"
     zip-dir "1.0.2"
 
+webextension-polyfill@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/webextension-polyfill/-/webextension-polyfill-0.3.1.tgz#fab2aed917a713a5d8221e41febad81c5d0b080f"
+  integrity sha512-ISB42vlgMyM7xE1u6pREeCqmmXjLsYu/nqAR8Dl/gIAnylb+KpRpvKbVkUYNFePhhXn0Obkkc3jasOII9ztUtg==
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"


### PR DESCRIPTION
Adds [`mozilla/webextension-polyfill`](https://github.com/mozilla/webextension-polyfill).

This allows us to use the soon-to-be-standardized (according to the polyfill documentation and MDN), promise-based APIs across browsers.

We are using, for instance, [`storage.get()`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get) and [`storage.set()`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set).

Additionally, switching to the promise-based APIs also seems like an improvement, because we've updated our adapter code to use `async` & `await` and we now handle other asynchronous behavior in the same, consistent way.

Another small but nice side-effect is that we can drop some linting exceptions.