### PR TITLE
Update Jira adapter to use REST APIs for fetching ticket info

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,4 +10,5 @@ module.exports = {
     '^.+\\.jsx?$': 'babel-jest',
     '^.+\\.png$': '<rootDir>/test/transforms/file.js',
   },
+  transformIgnorePatterns: ['node_modules/(?!ky)'],
 };

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
   "dependencies": {
     "@githubprimer/octicons-react": "^8.5.0",
     "bootstrap": "4.3.1",
+    "ky": "^0.9.0",
+    "micro-match": "^0.2.0",
     "prop-types": "15.7.2",
     "react": "16.8.4",
     "react-dom": "16.8.4",

--- a/src/common/__snapshots__/client.test.js.snap
+++ b/src/common/__snapshots__/client.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`client creates a new client with default values 1`] = `
+Array [
+  Array [
+    Object {
+      "credentials": "include",
+      "headers": Object {
+        "accept": "application/json",
+        "content-type": "application/json; charset=utf-8",
+      },
+      "prefixUrl": "https://example.io/api",
+      "timeout": 1000,
+    },
+  ],
+]
+`;
+
+exports[`client sets custom options 1`] = `
+Array [
+  Array [
+    Object {
+      "credentials": "same-origin",
+      "headers": Object {
+        "accept": "application/json",
+        "content-type": "application/json; charset=utf-8",
+      },
+      "prefixUrl": "https://example.io/api",
+      "timeout": 1000,
+    },
+  ],
+]
+`;

--- a/src/common/adapters/jira.test.js
+++ b/src/common/adapters/jira.test.js
@@ -1,203 +1,96 @@
 import { JSDOM } from 'jsdom';
 
+import client from '../client';
 import scan from './jira';
 
-// parts of the dom of the jira backlog issue-list
-// contains two tickets - one of them being selected
-const BACKLOG = `
-  <div class="ghx-backlog-column">
-    <div class="ghx-backlog-card ghx-selected">
-      <div class="ghx-issue-content">
-        <div class="ghx-row ghx-plan-main-fields">
-          <span class="ghx-backlog-card-expander-spacer"></span>
-          <span class="ghx-type items-spacer" title="Story">
-            <img src="https://someorg.atlassian.net/secure/viewavatar?size=xsmall&amp;avatarId=12345&amp;avatarType=issuetype">
-          </span>
-          <div class="ghx-summary" data-tooltip="A Random JIRA Backlog Issue">
-            <span class="ghx-inner">A Random JIRA Backlog Issue</span>
-          </div>
-        </div>
-        <div class="ghx-row ghx-end ghx-items-container">
-          <span class="aui-lozenge ghx-label ghx-label-single ghx-label-3" title="Chores" data-epickey="UXPL-123">
-            Chores
-          </span>
-          <span class="ghx-end ghx-items-container">
-            <a href="/browse/UXPL-39" title="UXPL-39" class="ghx-key js-key-link">
-              UXPL-39
-            </a>
-            <span class="ghx-priority" title="Medium">
-              <img src="https://someorg.atlassian.net/images/icons/priorities/medium.svg">
-            </span>
-            <span class="aui-badge ghx-spacer ghx-statistic-badge"></span>
-          </span>
-        </div>
-      </div>
-    </div>
-    <div class="ghx-backlog-card">
-      <div class="ghx-issue-content">
-        <div class="ghx-row ghx-plan-main-fields">
-          <span class="ghx-backlog-card-expander-spacer"></span>
-          <span class="ghx-type items-spacer" title="Bug">
-            <img src="https://someorg.atlassian.net/secure/viewavatar?size=xsmall&amp;avatarId=12345&amp;avatarType=issuetype">
-          </span>
-          <div class="ghx-summary" data-tooltip="A Random JIRA Bug Issue">
-            <span class="ghx-inner">A Random JIRA Bug Issue</span>
-          </div>
-        </div>
-        <div class="ghx-row ghx-end ghx-items-container">
-          <span class="aui-lozenge ghx-label ghx-label-single ghx-label-3" title="Chores" data-epickey="UXPL-123">
-            Chores
-          </span>
-          <span class="ghx-end ghx-items-container">
-            <a href="/browse/UXPL-47" title="UXPL-47" class="ghx-key js-key-link">
-              UXPL-47
-            </a>
-            <span class="ghx-priority" title="Low">
-              <img src="https://someorg.atlassian.net/images/icons/priorities/low.svg">
-            </span>
-            <span class="aui-badge ghx-spacer ghx-statistic-badge"></span>
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-`;
-const BUG_BACKLOG = BACKLOG.replace(/Story/, 'Bug');
-const CHORE_BACKLOG = BACKLOG.replace(/Story/, 'Chore');
-const BACKLOG_TWO_TICKETS_SELECTED = BACKLOG.replace('<div class="ghx-backlog-card">', '<div class="ghx-backlog-card ghx-selected">');
+jest.mock('../client', () => jest.fn());
 
-const STORYPAGE = `
-  <div id="issue-content">
-    <div class="issue-header-content">
-      <a class="issue-link" data-issue-key="UXPL-39" id="key-val">UXPL-39</a>
-      <h1 id="summary-val">A Random JIRA Issue</h1>
-    </div>
-    <div class="issue-body-content">
-      <span id="type-val" class="value editable-field inactive">
-        <img alt="" src="/" title="Story - A story"> Story
-      </span>
-    </div>
-  </div>
-`;
+const key = 'RC-654';
 
-const STORYPAGE_TITLE_EDITED = `
-  <div id="issue-content">
-    <div class="issue-header-content">
-      <a class="issue-link" data-issue-key="UXPL-39" id="key-val">UXPL-39</a>
-      <h1 id="summary-val" class="editable-field active">
-        <form id="summary-form">
-          <textarea id="summary">A Random JIRA Issue</textarea>
-          <button type="submit">Save</button>
-            <button type="cancel">Cancel</button>
-        </form>
-      </h1>
-    </div>
-    <div class="issue-body-content">
-      <span id="type-val" class="value editable-field inactive">
-        <img alt="" src="/" title="Story - A story"> Story
-      </span>
-    </div>
-  </div>
-`;
+const response = {
+  id: '10959',
+  fields: {
+    issuetype: { name: 'Story' },
+    summary: 'A quick summary of the ticket',
+  },
+  key,
+};
 
-const CHOREPAGE = STORYPAGE.replace(/Story/gi, 'Chore');
-const BUGPAGE = STORYPAGE.replace(/Story/gi, 'Bug');
-
-const BOARD_STORY = `
-<div class="ghx-columns">
-  <div class="ghx-column">
-    <div class="ghx-issue ghx-selected">
-      <section class="ghx-summary" title="">A Random JIRA Board Issue</section>
-      <section class="ghx-extra-fields">
-        <div class="ghx-row"><span class="ghx-extra-field ghx-fa"><span class="ghx-extra-field-content">None</span></span></div>
-      </section>
-      <section class="ghx-stat-fields">
-        <div class="ghx-row ghx-stat-1">
-          <span class="ghx-field ghx-field-icon" data-tooltip="Story"><img src=""></span>
-          <span class="ghx-field ghx-field-icon" data-tooltip="Some other thing"><img src=""></span>
-          <span class="ghx-field"></span><span class="ghx-field"><img src="" class="ghx-avatar-img"></span></div>
-      <div class="ghx-row ghx-stat-2">
-          <span class="ghx-field"><img src="" class="ghx-avatar-img"></span>
-          <a href="/browse/UXPL-39" aria-label="UXPL-39" data-tooltip="UXPL-39" tabindex="-1" class="ghx-key">
-            <span class="ghx-issuekey-pkey js-key-link" aria-hidden="true">UXPL</span>
-            <span class="ghx-issuekey-number js-key-link" aria-hidden="true">39-</span>
-          </a>
-        </div>
-      </section>
-    </div>
-  </div>
-</div>
-`;
-
-const BOARD_CHORE = BOARD_STORY.replace(/Story/gi, 'Chore');
-const BOARD_BUG = BOARD_STORY.replace(/Story/gi, 'Bug');
+const ticket = {
+  id: response.key,
+  title: response.fields.summary,
+  type: response.fields.issuetype.name.toLowerCase(),
+};
 
 describe('jira adapter', () => {
-  function doc(body = '', id = 'jira') {
-    const { window } = new JSDOM(`<html><body id="${id}">${body}</body></html>`);
-    return window.document;
+  function loc(host, pathname = '', params = null) {
+    const searchParams = new URLSearchParams(params || {});
+    const href = params
+      ? `https://${host}${pathname}?${searchParams}`
+      : `https://${host}${pathname}`;
+
+    return {
+      host,
+      href,
+      pathname,
+      search: searchParams.toString(),
+    };
   }
 
-  it('returns null if it is on a different page', async () => {
-    const result = await scan(null, doc(STORYPAGE, 'foo'));
+  const dom = new JSDOM('<html><body id="jira">…</body"</html>');
+  const doc = dom.window.document;
+
+  const api = { get: jest.fn() };
+
+  beforeEach(() => {
+    api.get.mockReturnValue({ json: () => response });
+    client.mockReturnValue(api);
+  });
+
+  afterEach(() => {
+    api.get.mockReset();
+    client.mockReset();
+  });
+
+  it('returns null when on a different host', async () => {
+    const result = await scan(loc('another-domain.com'), doc);
+    expect(api.get).not.toHaveBeenCalled();
     expect(result).toBe(null);
   });
 
-  it('extracts story tickets from a ticket page', async () => {
-    const result = await scan(null, doc(STORYPAGE));
-    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Issue', type: 'feature' }]);
+  it('returns null when no issue is selected', async () => {
+    const result = await scan(loc('my-subdomain.atlassian.com'), doc);
+    expect(api.get).not.toHaveBeenCalled();
+    expect(result).toBe(null);
   });
 
-  it('extracts story tickets from a ticket page even when the title is being edited', async () => {
-    const result = await scan(null, doc(STORYPAGE_TITLE_EDITED));
-    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Issue', type: 'feature' }]);
+  it('uses the endpoints for the current host', async () => {
+    await scan(loc('my-subdomain.atlassian.net', '', { selectedIssue: key }), doc);
+    expect(client).toHaveBeenCalledWith('https://my-subdomain.atlassian.net/rest/api/latest');
+    expect(api.get).toHaveBeenCalled();
   });
 
-  it('extracts bug tickets from a ticket page', async () => {
-    const result = await scan(null, doc(BUGPAGE));
-    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Issue', type: 'bug' }]);
+  it('extracts tickets from the active sprints tab', async () => {
+    const result = await scan(loc('my-subdomain.atlassian.net', '', { selectedIssue: key }), doc);
+    expect(api.get).toHaveBeenCalledWith(`issue/${key}`);
+    expect(result).toEqual([ticket]);
   });
 
-  it('extracts chore tickets from a ticket page', async () => {
-    const result = await scan(null, doc(CHOREPAGE));
-    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Issue', type: 'chore' }]);
+  it('extracts tickets from the issues tab', async () => {
+    const result = await scan(loc('my-subdomain.atlassian.net', `/projects/RC/issues/${key}`, { filter: 'something' }), doc);
+    expect(api.get).toHaveBeenCalledWith(`issue/${key}`);
+    expect(result).toEqual([ticket]);
   });
 
-  it('extracts tickets from the backlog', async () => {
-    const result = await scan(null, doc(BACKLOG));
-    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'feature' }]);
+  it('extracts tickets when browsing an issue', async () => {
+    const result = await scan(loc('my-subdomain.atlassian.net', `/browse/${key}`), doc);
+    expect(api.get).toHaveBeenCalledWith(`issue/${key}`);
+    expect(result).toEqual([ticket]);
   });
 
-  it('extracts bug tickets from the backlog', async () => {
-    const result = await scan(null, doc(BUG_BACKLOG));
-    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'bug' }]);
-  });
-
-  it('extracts chore tickets from the backlog', async () => {
-    const result = await scan(null, doc(CHORE_BACKLOG));
-    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'chore' }]);
-  });
-
-  it('extracts tickets from the backlog when multiple tickets are selected', async () => {
-    const result = await scan(null, doc(BACKLOG_TWO_TICKETS_SELECTED));
-    expect(result).toEqual([
-      { id: 'UXPL-39', title: 'A Random JIRA Backlog Issue', type: 'feature' },
-      { id: 'UXPL-47', title: 'A Random JIRA Bug Issue', type: 'bug' },
-    ]);
-  });
-
-  it('extracts selected tickets from the board', async () => {
-    const result = await scan(null, doc(BOARD_STORY));
-    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Board Issue', type: 'feature' }]);
-  });
-
-  it('extracts selected bug tickets from the board', async () => {
-    const result = await scan(null, doc(BOARD_BUG));
-    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Board Issue', type: 'bug' }]);
-  });
-
-  it('extracts selected chore tickets from the board', async () => {
-    const result = await scan(null, doc(BOARD_CHORE));
-    expect(result).toEqual([{ id: 'UXPL-39', title: 'A Random JIRA Board Issue', type: 'chore' }]);
+  it('extracts tickets on self-hosted instances', async () => {
+    const result = await scan(loc('jira.local', `/browse/${key}`), doc);
+    expect(client).toHaveBeenCalledWith('https://jira.local/rest/api/latest');
+    expect(result).toEqual([ticket]);
   });
 });

--- a/src/common/client.js
+++ b/src/common/client.js
@@ -7,9 +7,15 @@ const headers = {
   accept: 'application/json',
 };
 
+const timeout = 1000;
+
 function client(base, options = {}) {
   return ky.extend({
-    credentials, headers, prefixUrl: base, timeout: 1000, ...options,
+    prefixUrl: base,
+    credentials,
+    headers,
+    timeout,
+    ...options,
   });
 }
 

--- a/src/common/client.js
+++ b/src/common/client.js
@@ -1,0 +1,16 @@
+import ky from 'ky';
+
+const credentials = 'include';
+
+const headers = {
+  'content-type': 'application/json; charset=utf-8',
+  accept: 'application/json',
+};
+
+function client(base, options = {}) {
+  return ky.extend({
+    credentials, headers, prefixUrl: base, timeout: 1000, ...options,
+  });
+}
+
+export default client;

--- a/src/common/client.test.js
+++ b/src/common/client.test.js
@@ -1,0 +1,31 @@
+import ky from 'ky';
+
+import client from './client';
+
+jest.mock('ky', () => ({
+  extend: jest.fn(),
+}));
+
+describe('client', () => {
+  const mock = { ky: true };
+
+  beforeEach(() => {
+    ky.extend.mockReturnValue(mock);
+  });
+
+  afterEach(() => {
+    ky.extend.mockReset();
+  });
+
+  it('creates a new client with default values', () => {
+    const instance = client('https://example.io/api');
+    expect(ky.extend.mock.calls).toMatchSnapshot();
+    expect(instance).toBe(mock);
+  });
+
+  it('sets custom options', () => {
+    const instance = client('https://example.io/api', { credentials: 'same-origin', timeout: 1000 });
+    expect(ky.extend.mock.calls).toMatchSnapshot();
+    expect(instance).toBe(mock);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6261,6 +6261,11 @@ kleur@^3.0.2:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.2.tgz#83c7ec858a41098b613d5998a7b653962b504f68"
   integrity sha512-3h7B2WRT5LNXOtQiAaWonilegHcPSf9nLVXlSTci8lu1dZUuui61+EsPEZqSVxY7rXYmB2DVKMQILxaO5WL61Q==
 
+ky@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/ky/-/ky-0.9.0.tgz#f6ca68417e1c95e0292d083d5c3c4c39558c13fe"
+  integrity sha512-5OgdeZ/HROtJh6ghuSARGIe4Y0SzY+eM7EY5YEvlVVBmp3V2ioz1erGRYaf55uMUG0jTkE+L8USxD+oiRmgX8A==
+
 latest-version@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
@@ -6668,6 +6673,11 @@ merge-stream@^1.0.1:
   integrity sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=
   dependencies:
     readable-stream "^2.0.1"
+
+micro-match@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/micro-match/-/micro-match-0.2.0.tgz#56c260bf9a3a34f42bc9db613de62cbdd1df5774"
+  integrity sha512-BcxPv/ocMU12ObTOiGRAc5xP4HfkpWrWpldNJzmpJpkLhQ9VJr8dSCN/iz2RYIKT2vJkVP8jdyEmCNA2n000dQ==
 
 micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"


### PR DESCRIPTION
Update the JIRA adapter to fetch the ticket info via HTTP request instead of scraping the document.

Here's the documentation of the REST APIs: https://developer.atlassian.com/cloud/jira/software/rest/

I tested the changes both with Chrome and Firefox.

TODO:

- [x] Update adapter code to determine the proper URL base (including path prefix) instead of just using the hostname
- [x] Test on self-hosted Jira instance
- [ ] Test with Safari
- [ ] Test with Opera

Side notes:

- The package [`ky`](https://github.com/sindresorhus/ky) has been added and it is used as HTTP client