### PR TITLE
Update Trello adapter to use REST APIs for fetching ticket info

### DIFF
--- a/src/common/adapters/__helpers__/location.js
+++ b/src/common/adapters/__helpers__/location.js
@@ -1,0 +1,10 @@
+export default function loc(host, pathname = '/', search = '') {
+  const href = `https://${host}${pathname}${search}`;
+
+  return {
+    host,
+    href,
+    pathname,
+    search,
+  };
+}

--- a/src/common/adapters/jira.test.js
+++ b/src/common/adapters/jira.test.js
@@ -3,6 +3,8 @@ import { JSDOM } from 'jsdom';
 import client from '../client';
 import scan from './jira';
 
+import loc from './__helpers__/location';
+
 jest.mock('../client', () => jest.fn());
 
 const key = 'RC-654';
@@ -23,17 +25,6 @@ const ticket = {
 };
 
 describe('jira adapter', () => {
-  function loc(host, pathname = '/', search = '') {
-    const href = `https://${host}${pathname}${search}`;
-
-    return {
-      host,
-      href,
-      pathname,
-      search,
-    };
-  }
-
   const dom = new JSDOM('<html><body id="jira">…</body"</html>');
   const doc = dom.window.document;
 

--- a/src/common/adapters/trello.js
+++ b/src/common/adapters/trello.js
@@ -1,16 +1,33 @@
-import { $has, $text } from './helpers';
+// Trello adapter
+//
+// This adapter extracts the identifier of the selected card (short link) from
+// the page URL and uses the Trello API to retrieve the corresponding card
+// information.
+//
+// https://developers.trello.com/v1.0/reference#introduction
+//
+// Card view: https://trello.com/c/<SHORT-LINK>/1-ticket-title
 
-async function scan(loc, doc) {
-  if (loc.host !== 'trello.com') return null;
-  if (!$has('.card-detail-window', doc)) return null;
+import match from 'micro-match';
 
-  const id = loc.pathname.match(/\/([\d]+)-[^/]+$/)[1];
-  const title = $text('.card-detail-title-assist', doc);
-  const type = 'feature';
+import client from '../client';
 
-  const tickets = [{ id, title, type }];
+async function scan(loc) {
+  const { host, pathname } = loc;
 
-  return tickets;
+  if (host !== 'trello.com') return null;
+
+  const { key } = match('/c/:key/:slug', pathname);
+
+  if (!key) return null;
+
+  const trello = client('https://trello.com/1');
+  const response = await trello.get(`cards/${key}`).json();
+
+  const { idShort: id, name: title } = response;
+  const ticket = { id, title, type: 'feature' };
+
+  return [ticket];
 }
 
 export default scan;

--- a/src/common/adapters/trello.js
+++ b/src/common/adapters/trello.js
@@ -12,20 +12,35 @@ import match from 'micro-match';
 
 import client from '../client';
 
+function extractTicketInfo(response) {
+  const {
+    desc: description,
+    name: title,
+    shortLink: id,
+    shortUrl: url,
+  } = response;
+
+  return {
+    type: 'feature',
+    id,
+    title,
+    description,
+    url,
+  };
+}
+
+const requestOptions = { searchParams: { fields: 'name,desc,shortLink,shortUrl' } };
+
 async function scan(loc) {
-  const { host, pathname } = loc;
+  if (loc.host !== 'trello.com') return null;
 
-  if (host !== 'trello.com') return null;
-
-  const { key } = match('/c/:key/:slug', pathname);
+  const { key } = match('/c/:key/:slug', loc.pathname);
 
   if (!key) return null;
 
   const trello = client('https://trello.com/1');
-  const response = await trello.get(`cards/${key}`).json();
-
-  const { idShort: id, name: title } = response;
-  const ticket = { id, title, type: 'feature' };
+  const response = await trello.get(`cards/${key}`, requestOptions).json();
+  const ticket = extractTicketInfo(response);
 
   return [ticket];
 }

--- a/src/common/adapters/trello.test.js
+++ b/src/common/adapters/trello.test.js
@@ -7,11 +7,26 @@ jest.mock('../client', () => jest.fn());
 
 const key = 'haKn65Sy';
 
-const idShort = '123';
+const shortLink = key;
 const name = 'A quick summary of the card';
-const slug = '123-a-quick-summary-of-the-card';
+const slug = '4-a-quick-summary-of-the-card';
+const desc = 'A detailed description of the card';
+const shortUrl = `https://trello.com/c/${shortLink}`;
 
-const response = { idShort, name };
+const response = {
+  desc,
+  name,
+  shortLink,
+  shortUrl,
+};
+
+const ticket = {
+  id: shortLink,
+  title: name,
+  description: desc,
+  url: shortUrl,
+  type: 'feature',
+};
 
 describe('trello adapter', () => {
   const api = { get: jest.fn() };
@@ -47,7 +62,9 @@ describe('trello adapter', () => {
   it('extracts tickets from the current card', async () => {
     const result = await scan(loc('trello.com', `/c/${key}/${slug}`));
     expect(client).toHaveBeenCalledWith('https://trello.com/1');
-    expect(api.get).toHaveBeenCalledWith(`cards/${key}`);
-    expect(result).toEqual([{ id: idShort, title: name, type: 'feature' }]);
+    expect(api.get).toHaveBeenCalledWith(`cards/${key}`, {
+      searchParams: { fields: 'name,desc,shortLink,shortUrl' },
+    });
+    expect(result).toEqual([ticket]);
   });
 });

--- a/src/common/adapters/trello.test.js
+++ b/src/common/adapters/trello.test.js
@@ -1,28 +1,53 @@
-import { JSDOM } from 'jsdom';
-
+import client from '../client';
 import scan from './trello';
 
-const CARD = `
-  <div class="card-detail-window">
-    <h2 class="card-detail-title-assist">A Trello Card</h2>
-  </div>
-`;
+import loc from './__helpers__/location';
+
+jest.mock('../client', () => jest.fn());
+
+const key = 'haKn65Sy';
+
+const idShort = '123';
+const name = 'A quick summary of the card';
+const slug = '123-a-quick-summary-of-the-card';
+
+const response = { idShort, name };
 
 describe('trello adapter', () => {
-  const loc = { host: 'trello.com', pathname: '/c/kkRPwRqw/89-a-trello-card' };
+  const api = { get: jest.fn() };
 
-  function doc(body = '') {
-    const { window } = new JSDOM(`<html><body>${body}</body></html>`);
-    return window.document;
-  }
+  beforeEach(() => {
+    api.get.mockReturnValue({ json: () => response });
+    client.mockReturnValue(api);
+  });
 
-  it('returns null if it is on a different page', async () => {
-    const result = await scan({ host: 'other.com' }, doc(CARD));
+  afterEach(() => {
+    api.get.mockReset();
+    client.mockReset();
+  });
+
+  it('returns null when on a different host', async () => {
+    const result = await scan(loc('another-domain.com'));
+    expect(api.get).not.toHaveBeenCalled();
     expect(result).toBe(null);
   });
 
-  it('extracts tickets from trello cards', async () => {
-    const result = await scan(loc, doc(CARD));
-    expect(result).toEqual([{ id: '89', title: 'A Trello Card', type: 'feature' }]);
+  it('returns null when on a different view', async () => {
+    const result = await scan(loc('trello.com', '/another/url'));
+    expect(api.get).not.toHaveBeenCalled();
+    expect(result).toBe(null);
+  });
+
+  it('uses the correct endpoint', async () => {
+    await scan(loc('trello.com', '/c/aghy1jdk/1-ticket-title'));
+    expect(client).toHaveBeenCalledWith('https://trello.com/1');
+    expect(api.get).toHaveBeenCalled();
+  });
+
+  it('extracts tickets from the current card', async () => {
+    const result = await scan(loc('trello.com', `/c/${key}/${slug}`));
+    expect(client).toHaveBeenCalledWith('https://trello.com/1');
+    expect(api.get).toHaveBeenCalledWith(`cards/${key}`);
+    expect(result).toEqual([{ id: idShort, title: name, type: 'feature' }]);
   });
 });


### PR DESCRIPTION
Based on #137 

Here the documentation of the REST APIs: https://developers.trello.com/v1.0/reference#introduction

I tested the changes both with Firefox

**TODO:**
- [x] test with Chrome
- [x] test with Safari
- [x] test with Opera
