### PR TITLE
Additions for the new Jira adapter

### DIFF
--- a/src/common/adapters/jira.js
+++ b/src/common/adapters/jira.js
@@ -13,6 +13,12 @@ import match from 'micro-match';
 
 import client from '../client';
 
+function isJiraPage(loc, doc) {
+  if (loc.host.endsWith('.atlassian.net')) return true;
+  if (doc.body.id === 'jira') return true;
+  return false;
+}
+
 function getSelectedIssueId({ href, pathname }) {
   const { searchParams: params } = new URL(href);
 
@@ -29,16 +35,14 @@ function extractTicketInfo(response) {
   return { id, title, type };
 }
 
-async function scan(loc) {
-  const { host } = loc;
-
-  if (!host.endsWith('.atlassian.net')) return null;
+async function scan(loc, doc) {
+  if (!isJiraPage(loc, doc)) return null;
 
   const id = getSelectedIssueId(loc);
 
   if (!id) return null;
 
-  const jira = client(`https://${host}/rest/agile/1.0`);
+  const jira = client(`https://${loc.host}/rest/agile/1.0`);
   const response = await jira.get(`issue/${id}`).json();
   const ticket = extractTicketInfo(response);
 

--- a/src/common/adapters/jira.test.js
+++ b/src/common/adapters/jira.test.js
@@ -23,8 +23,8 @@ const ticket = {
 };
 
 describe('jira adapter', () => {
-  function loc(host, pathname = '', params = {}) {
-    const searchParams = new URLSearchParams(params);
+  function loc(host, pathname = '', params = null) {
+    const searchParams = new URLSearchParams(params || {});
     const href = params
       ? `https://${host}${pathname}?${searchParams}`
       : `https://${host}${pathname}`;

--- a/src/common/adapters/jira.test.js
+++ b/src/common/adapters/jira.test.js
@@ -3,19 +3,21 @@ import scan from './jira';
 
 jest.mock('../client', () => jest.fn());
 
-const selectedIssue = 'RC-654';
-const issueType = 'Story';
-const title = 'A quick summary of the ticket';
+const key = 'RC-654';
 
 const response = {
   id: '10959',
-  key: selectedIssue,
   fields: {
-    issuetype: {
-      name: issueType,
-    },
-    summary: title,
+    issuetype: { name: 'Story' },
+    summary: 'A quick summary of the ticket',
   },
+  key,
+};
+
+const ticket = {
+  id: response.key,
+  title: response.fields.summary,
+  type: response.fields.issuetype.name.toLowerCase(),
 };
 
 describe('jira adapter', () => {
@@ -50,42 +52,27 @@ describe('jira adapter', () => {
     expect(result).toBe(null);
   });
 
-  it('returns null when the selected issue is missing', async () => {
+  it('returns null when no issue is selected', async () => {
     const result = await scan(loc('my-subdomain.atlassian.com'));
     expect(api.get).not.toHaveBeenCalled();
     expect(result).toBe(null);
   });
 
   it('extracts tickets from the active sprints tab', async () => {
-    const result = await scan(loc('my-subdomain.atlassian.net', '', { selectedIssue }));
-
-    expect(api.get).toHaveBeenCalledWith(`issue/${selectedIssue}`);
-    expect(result).toEqual([{
-      id: selectedIssue,
-      title,
-      type: issueType.toLowerCase(),
-    }]);
+    const result = await scan(loc('my-subdomain.atlassian.net', '', { selectedIssue: key }));
+    expect(api.get).toHaveBeenCalledWith(`issue/${key}`);
+    expect(result).toEqual([ticket]);
   });
 
   it('extracts tickets from the issues tab', async () => {
-    const result = await scan(loc('my-subdomain.atlassian.net', `/projects/RC/issues/${selectedIssue}`, { filter: 'something' }));
-
-    expect(api.get).toHaveBeenCalledWith(`issue/${selectedIssue}`);
-    expect(result).toEqual([{
-      id: selectedIssue,
-      title,
-      type: issueType.toLowerCase(),
-    }]);
+    const result = await scan(loc('my-subdomain.atlassian.net', `/projects/RC/issues/${key}`, { filter: 'something' }));
+    expect(api.get).toHaveBeenCalledWith(`issue/${key}`);
+    expect(result).toEqual([ticket]);
   });
 
   it('extracts tickets when browsing an issue', async () => {
-    const result = await scan(loc('my-subdomain.atlassian.net', `/browse/${selectedIssue}`));
-
-    expect(api.get).toHaveBeenCalledWith(`issue/${selectedIssue}`);
-    expect(result).toEqual([{
-      id: selectedIssue,
-      title,
-      type: issueType.toLowerCase(),
-    }]);
+    const result = await scan(loc('my-subdomain.atlassian.net', `/browse/${key}`));
+    expect(api.get).toHaveBeenCalledWith(`issue/${key}`);
+    expect(result).toEqual([ticket]);
   });
 });


### PR DESCRIPTION
* Add support for self-hosted Jira instances (as long as they use the REST API)
* Tests that API requests are made against the correct endpoints/host
* Small refactoring