### PR TITLE
Adjust number of Jest workers on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - restore_cache:
           key: repo-{{ .Environment.CIRCLE_SHA1 }}
-      - run: yarn test
+      - run: yarn test --maxWorkers=2
 workflows:
   version: 2
   checks:


### PR DESCRIPTION
The default maximum number of workers in Jest is equal to the number of
cores available on a machine. However, when running inside a Circle CI
Docker container, Jest sets this value to 35 causing tests to be slowed
down.

This commit explicitly sets the maximum number of workers to the actual
number of vCPUs for the Circle CI environment (2).

For a comparison:

- `test` job on master: https://circleci.com/gh/bitcrowd/tickety-tick/27#build-timing/containers/0/actions/102 — `Done in 11.34s.` (with test duration warnings)
- `test` job on this branch: https://circleci.com/gh/bitcrowd/tickety-tick/35#build-timing/containers/0 — `Done in 6.49s.`

References:

- Default Circle CI Docker executor has 2 vCPUs: https://circleci.com/docs/2.0/configuration-reference/#resource_class
- Jest using 35 `maxWorkers` without explicit value on Circle CI (see debug output): https://circleci.com/gh/bitcrowd/tickety-tick/32
- Jest `maxWorkers` option: https://jestjs.io/docs/en/cli#maxworkers-num-string
- Jest "troubleshooting" entry: https://jestjs.io/docs/en/troubleshooting#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server