### PR TITLE
Update jira adapter to use rest endpoint 2

### DIFF
--- a/src/common/adapters/jira.js
+++ b/src/common/adapters/jira.js
@@ -13,43 +13,36 @@ import match from 'micro-match';
 
 import client from '../client';
 
-const DOMAIN = '.atlassian.net';
-
-const issueTabMatch = '/projects/:project/issues/:id';
-const browseIssueMatch = '/browse/:id';
-
-function selectedIssue({ href, pathname }) {
-  let id = null;
-
+function getSelectedIssueId({ href, pathname }) {
   const { searchParams: params } = new URL(href);
-  id = params.get('selectedIssue');
-  if (id) return id;
 
-  ({ id } = { ...match(issueTabMatch, pathname), ...match(browseIssueMatch, pathname) });
+  if (params.has('selectedIssue')) return params.get('selectedIssue');
 
-  return id;
+  return ['/projects/:project/issues/:id', '/browse/:id']
+    .map(pattern => match(pattern, pathname).id)
+    .find(Boolean);
 }
 
 function extractTicketInfo(response) {
-  const { key: id, fields } = response;
-  const { issuetype, summary: title } = fields;
+  const { key: id, fields: { issuetype, summary: title } } = response;
   const type = issuetype.name.toLowerCase();
-
   return { id, title, type };
 }
 
 async function scan(loc) {
   const { host } = loc;
-  if (!host.endsWith(DOMAIN)) return null;
 
-  const issueKey = selectedIssue(loc);
-  if (!issueKey) return null;
+  if (!host.endsWith('.atlassian.net')) return null;
+
+  const id = getSelectedIssueId(loc);
+
+  if (!id) return null;
 
   const jira = client(`https://${host}/rest/api/latest`);
-  const response = await jira.get(`issue/${issueKey}`).json();
-  const ticketInfo = extractTicketInfo(response);
+  const response = await jira.get(`issue/${id}`).json();
+  const ticket = extractTicketInfo(response);
 
-  return [ticketInfo];
+  return [ticket];
 }
 
 export default scan;

--- a/src/common/adapters/jira.js
+++ b/src/common/adapters/jira.js
@@ -13,6 +13,12 @@ import match from 'micro-match';
 
 import client from '../client';
 
+function isJiraPage(loc, doc) {
+  if (loc.host.endsWith('.atlassian.net')) return true;
+  if (doc.body.id === 'jira') return true;
+  return false;
+}
+
 function getSelectedIssueId({ href, pathname }) {
   const { searchParams: params } = new URL(href);
 
@@ -29,10 +35,8 @@ function extractTicketInfo(response) {
   return { id, title, type };
 }
 
-async function scan(loc) {
-  const { host } = loc;
-
-  if (!host.endsWith('.atlassian.net')) return null;
+async function scan(loc, doc) {
+  if (!isJiraPage(loc, doc)) return null;
 
   const id = getSelectedIssueId(loc);
 

--- a/src/common/adapters/jira.js
+++ b/src/common/adapters/jira.js
@@ -42,7 +42,7 @@ async function scan(loc, doc) {
 
   if (!id) return null;
 
-  const jira = client(`https://${host}/rest/api/latest`);
+  const jira = client(`https://${loc.host}/rest/api/latest`);
   const response = await jira.get(`issue/${id}`).json();
   const ticket = extractTicketInfo(response);
 

--- a/src/common/adapters/jira.test.js
+++ b/src/common/adapters/jira.test.js
@@ -66,7 +66,7 @@ describe('jira adapter', () => {
 
   it('uses the endpoints for the current host', async () => {
     await scan(loc('my-subdomain.atlassian.net', '', { selectedIssue: key }), doc);
-    expect(client).toHaveBeenCalledWith('https://my-subdomain.atlassian.net/rest/agile/1.0');
+    expect(client).toHaveBeenCalledWith('https://my-subdomain.atlassian.net/rest/api/latest');
     expect(api.get).toHaveBeenCalled();
   });
 
@@ -90,7 +90,7 @@ describe('jira adapter', () => {
 
   it('extracts tickets on self-hosted instances', async () => {
     const result = await scan(loc('jira.local', `/browse/${key}`), doc);
-    expect(client).toHaveBeenCalledWith('https://jira.local/rest/agile/1.0');
+    expect(client).toHaveBeenCalledWith('https://jira.local/rest/api/latest');
     expect(result).toEqual([ticket]);
   });
 });

--- a/src/common/adapters/jira.test.js
+++ b/src/common/adapters/jira.test.js
@@ -23,8 +23,8 @@ const ticket = {
 };
 
 describe('jira adapter', () => {
-  function loc(host, pathname = '', params = {}) {
-    const searchParams = new URLSearchParams(params);
+  function loc(host, pathname = '', params = null) {
+    const searchParams = new URLSearchParams(params || {});
     const href = params
       ? `https://${host}${pathname}?${searchParams}`
       : `https://${host}${pathname}`;

--- a/src/common/adapters/jira.test.js
+++ b/src/common/adapters/jira.test.js
@@ -3,19 +3,21 @@ import scan from './jira';
 
 jest.mock('../client', () => jest.fn());
 
-const selectedIssue = 'RC-654';
-const issueType = 'Story';
-const title = 'A quick summary of the ticket';
+const key = 'RC-654';
 
 const response = {
   id: '10959',
-  key: selectedIssue,
   fields: {
-    issuetype: {
-      name: issueType,
-    },
-    summary: title,
+    issuetype: { name: 'Story' },
+    summary: 'A quick summary of the ticket',
   },
+  key,
+};
+
+const ticket = {
+  id: response.key,
+  title: response.fields.summary,
+  type: response.fields.issuetype.name.toLowerCase(),
 };
 
 describe('jira adapter', () => {
@@ -50,42 +52,27 @@ describe('jira adapter', () => {
     expect(result).toBe(null);
   });
 
-  it('returns null when the selected issue is missing', async () => {
+  it('returns null when no issue is selected', async () => {
     const result = await scan(loc('my-subdomain.atlassian.com'));
     expect(api.get).not.toHaveBeenCalled();
     expect(result).toBe(null);
   });
 
   it('extracts tickets from the active sprints tab', async () => {
-    const result = await scan(loc('my-subdomain.atlassian.net', '', { selectedIssue }));
-
-    expect(api.get).toHaveBeenCalledWith(`issue/${selectedIssue}`);
-    expect(result).toEqual([{
-      id: selectedIssue,
-      title,
-      type: issueType.toLowerCase(),
-    }]);
+    const result = await scan(loc('my-subdomain.atlassian.net', '', { selectedIssue: key }));
+    expect(api.get).toHaveBeenCalledWith(`issue/${key}`);
+    expect(result).toEqual([ticket]);
   });
 
   it('extracts tickets from the issues tab', async () => {
-    const result = await scan(loc('my-subdomain.atlassian.net', `/projects/RC/issues/${selectedIssue}`, { filter: 'something' }));
-
-    expect(api.get).toHaveBeenCalledWith(`issue/${selectedIssue}`);
-    expect(result).toEqual([{
-      id: selectedIssue,
-      title,
-      type: issueType.toLowerCase(),
-    }]);
+    const result = await scan(loc('my-subdomain.atlassian.net', `/projects/RC/issues/${key}`, { filter: 'something' }));
+    expect(api.get).toHaveBeenCalledWith(`issue/${key}`);
+    expect(result).toEqual([ticket]);
   });
 
   it('extracts tickets when browsing an issue', async () => {
-    const result = await scan(loc('my-subdomain.atlassian.net', `/browse/${selectedIssue}`));
-
-    expect(api.get).toHaveBeenCalledWith(`issue/${selectedIssue}`);
-    expect(result).toEqual([{
-      id: selectedIssue,
-      title,
-      type: issueType.toLowerCase(),
-    }]);
+    const result = await scan(loc('my-subdomain.atlassian.net', `/browse/${key}`));
+    expect(api.get).toHaveBeenCalledWith(`issue/${key}`);
+    expect(result).toEqual([ticket]);
   });
 });


### PR DESCRIPTION
It re-applies the changes introduced by #139 which has been deleted accidentally.