### PR TITLE
[#143] Add a loading indicator

### DIFF
--- a/src/common/popup/popup.html
+++ b/src/common/popup/popup.html
@@ -5,6 +5,12 @@
     <title>Tickety-Tick</title>
   </head>
   <body>
-    <div id="popup-root" class="popup"></div>
+    <div id="popup-root" class="popup">
+      <div class="spinner">
+        <div class="bounce bounce-1"></div>
+        <div class="bounce bounce-2"></div>
+        <div class="bounce bounce-3"></div>
+      </div>
+    </div>
   </body>
 </html>

--- a/src/common/popup/popup.scss
+++ b/src/common/popup/popup.scss
@@ -34,3 +34,6 @@
 
 // Popup style
 @import "styles/additions";
+
+// Spinner
+@import "styles/spinner";

--- a/src/common/popup/styles/_spinner.scss
+++ b/src/common/popup/styles/_spinner.scss
@@ -1,0 +1,43 @@
+.spinner {
+  margin: 4rem auto 0;
+  width: 4rem;
+  text-align: center;
+}
+
+.spinner > .bounce {
+  width: 1rem;
+  height: 1rem;
+  margin: .125rem;
+  background-color: $gray-500;
+
+  border-radius: 100%;
+  display: inline-block;
+  -webkit-animation: spinner-bouncedelay 1.4s infinite ease-in-out both;
+  animation: spinner-bouncedelay 1.4s infinite ease-in-out both;
+}
+
+.spinner .bounce-1 {
+  -webkit-animation-delay: -0.32s;
+  animation-delay: -0.32s;
+}
+
+.spinner .bounce-2 {
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+}
+
+@-webkit-keyframes spinner-bouncedelay {
+  0%, 80%, 100% { -webkit-transform: scale(0) }
+  40% { -webkit-transform: scale(1.0) }
+}
+
+@keyframes spinner-bouncedelay {
+  0%, 80%, 100% { 
+    -webkit-transform: scale(0);
+    transform: scale(0);
+  }
+  40% { 
+    -webkit-transform: scale(1.0);
+    transform: scale(1.0);
+  }
+}


### PR DESCRIPTION
Add a super simple, pure CSS spinner that is shown while tickets are being loaded.

**Preview**

![preview](https://user-images.githubusercontent.com/706519/54400398-73aba180-46ba-11e9-87a6-e55c6983dad6.gif)


_Note_: I added an extra timeout for demo purposes. In reality users should never see it this long.

Also, the slight stutter in the preview is due to the GIF framerate.