### PR TITLE
Fix file copying in Webpack watch mode

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -84,6 +84,9 @@ config.module.rule('images')
   .loader('file-loader')
   .options({ name: '[name].[hash].[ext]' });
 
+config.plugin('clean')
+  .use(CleanWebpackPlugin, []);
+
 config.plugin('html')
   .use(HtmlWebpackPlugin, [{
     template: src.common('popup', 'popup.html'),
@@ -96,9 +99,6 @@ config.plugin('html')
     },
   }]);
 
-config.plugin('clean')
-  .use(CleanWebpackPlugin, []);
-
 config.plugin('extract')
   .use(MiniCssExtractPlugin, [{
     filename: '[name].css',
@@ -110,7 +110,9 @@ config.plugin('copy')
       from: src.common('icons', '*.png'),
       flatten: true,
     },
-  ]]);
+  ], {
+    copyUnmodified: true,
+  }]);
 
 config.plugin('notifier')
   .use(NotifierPlugin, [{

--- a/webpack.safari.babel.js
+++ b/webpack.safari.babel.js
@@ -14,7 +14,7 @@ config.output.path(dist('tickety-tick.safariextension'));
 
 // Copy Info.plist and Settings.plist in addition to the common files.
 
-config.plugin('copy').tap(([patterns]) => [[
+config.plugin('copy').tap(([patterns, options]) => [[
   ...patterns,
   {
     from: src.safari('Info.plist'),
@@ -26,6 +26,6 @@ config.plugin('copy').tap(([patterns]) => [[
   {
     from: src.safari('Settings.plist'),
   },
-]]);
+], options]);
 
 export default config.toConfig();

--- a/webpack.webext.babel.js
+++ b/webpack.webext.babel.js
@@ -38,7 +38,7 @@ config.plugin('options-html')
 
 // Copy the manifest.json template in addition to common files.
 
-config.plugin('copy').tap(([patterns]) => [[
+config.plugin('copy').tap(([patterns, options]) => [[
   ...patterns,
   {
     from: src.webext('manifest.json'),
@@ -63,7 +63,7 @@ config.plugin('copy').tap(([patterns]) => [[
       return JSON.stringify(mf);
     },
   },
-]]);
+], options]);
 
 config.when(process.env.BUNDLE === 'true', cfg => cfg
   .plugin('zip')


### PR DESCRIPTION
Related to https://github.com/bitcrowd/tickety-tick/commit/d66f04c011021cf48c525717909fd071f71d7d6b

The `clean-webpack-plugin` is removing all files in the Webpack output
path on every rebuild in watch mode. At the same time however, the
`copy-webpack-plugin` only copies files once during the initial build
and after that only copies modified files by default.

This explicitly instructs the copy plugin to copy all files on every
rebuild so it is safe for the clean plugin to wipe the complete output
path.