### PR TITLE
[#93] Enhance commit messages (part 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "bootstrap": "4.3.1",
     "ky": "^0.9.0",
     "micro-match": "^0.2.0",
+    "prettier": "^1.16.4",
     "prop-types": "15.7.2",
     "react": "16.8.4",
     "react-dom": "16.8.4",
@@ -75,6 +76,7 @@
     "react-router-dom": "4.3.1",
     "react-textarea-autosize": "^7.1.0",
     "speakingurl": "14.0.1",
+    "strip-indent": "^2.0.0",
     "webextension-polyfill": "^0.4.0"
   }
 }

--- a/src/common/format/__snapshots__/pretty-print.test.js.snap
+++ b/src/common/format/__snapshots__/pretty-print.test.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pretty-print formats lists 1`] = `
+"Format lists in body
+
+- Bullet points are okay too
+- Typically a hyphen or asterisk is used for the bullet, followed by a
+  single space, with blank lines in between, but conventions vary here
+- Use a hanging indent
+"
+`;
+
+exports[`pretty-print strips body indentation 1`] = `
+"Strip body indentation
+
+Unindent this line. Move this one up.
+
+    function leave(me) {
+      return 'indented';
+    }
+
+And continue.
+"
+`;
+
+exports[`pretty-print strips leading and trailing blank lines and whitespace 1`] = `
+"Remove whitespace around subject line
+
+Also, remove additional blank lines before and after body.
+
+Preserve blank lines between paragraphs of the body.
+
+Strip whitespace on empty lines (see line above).
+
+Strip trailing whitespace (see end of this line).
+"
+`;
+
+exports[`pretty-print wraps overlong body lines 1`] = `
+"Wrap body lines
+
+More detailed explanatory text is wrapped to 72 characters. The blank
+line separating the subject from the body is critical unless you omit
+the body entirely.
+"
+`;
+
+exports[`pretty-print wraps overlong subject lines 1`] = `
+"Wrap commit subject lines with more than 50…
+
+…characters and insert one blank line before the remaining subject text.
+Wrap the remaining subject text to 72 characters.
+"
+`;

--- a/src/common/format/pretty-print.js
+++ b/src/common/format/pretty-print.js
@@ -1,0 +1,56 @@
+import prettier from 'prettier/standalone';
+import markdown from 'prettier/parser-markdown';
+import unindent from 'strip-indent';
+
+const widths = { subject: 50, body: 72 };
+
+const config = { parser: 'markdown', plugins: [markdown] };
+
+function format(text, width) {
+  const options = { ...config, printWidth: width, proseWrap: 'always' };
+  return prettier.format(text, options);
+}
+
+function splitf(string, separator) {
+  const position = string.indexOf(separator);
+
+  if (position < 0) return [string];
+
+  const head = string.substring(0, position);
+  const tail = string.substring(position + separator.length);
+
+  return [head, tail];
+}
+
+function capitalizef(string) {
+  return string.replace(/[a-zA-Z]/, w => w.toUpperCase());
+}
+
+function gitsubject(string) {
+  const subject = capitalizef(string.trim());
+
+  if (subject.length > widths.subject) {
+    const [start, rest] = splitf(format(subject, widths.subject - 1), '\n');
+    return [`${start}…`, format(`…${rest}`, widths.body)].join('\n\n');
+  }
+
+  return subject;
+}
+
+function gitbody(string) {
+  const body = unindent(string.replace(/^(\s*\n)*|\s*$/, ''));
+  return format(body, widths.body);
+}
+
+function maybe(value, fn) {
+  if (typeof value !== 'string') return value;
+  return fn(value);
+}
+
+function print(input) {
+  const [line0, rest] = splitf(input.trim(), '\n');
+  const parts = [maybe(line0, gitsubject), maybe(rest, gitbody)];
+  return parts.filter(Boolean).join('\n\n');
+}
+
+export default print;

--- a/src/common/format/pretty-print.js
+++ b/src/common/format/pretty-print.js
@@ -11,7 +11,7 @@ function format(text, width) {
   return prettier.format(text, options);
 }
 
-function splitf(string, separator) {
+function split(string, separator) {
   const position = string.indexOf(separator);
 
   if (position < 0) return [string];
@@ -22,15 +22,15 @@ function splitf(string, separator) {
   return [head, tail];
 }
 
-function capitalizef(string) {
+function capitalize(string) {
   return string.replace(/[a-zA-Z]/, w => w.toUpperCase());
 }
 
 function gitsubject(string) {
-  const subject = capitalizef(string.trim());
+  const subject = capitalize(string.trim());
 
   if (subject.length > widths.subject) {
-    const [start, rest] = splitf(format(subject, widths.subject - 1), '\n');
+    const [start, rest] = split(format(subject, widths.subject - 1), '\n');
     return [`${start}…`, format(`…${rest}`, widths.body)].join('\n\n');
   }
 
@@ -48,7 +48,7 @@ function maybe(value, fn) {
 }
 
 function print(input) {
-  const [line0, rest] = splitf(input.trim(), '\n');
+  const [line0, rest] = split(input.trim(), '\n');
   const parts = [maybe(line0, gitsubject), maybe(rest, gitbody)];
   return parts.filter(Boolean).join('\n\n');
 }

--- a/src/common/format/pretty-print.test.js
+++ b/src/common/format/pretty-print.test.js
@@ -1,0 +1,69 @@
+import print from './pretty-print';
+
+describe('pretty-print', () => {
+  it('capitalizes subject lines', () => {
+    expect(print('apply proper casing')).toBe('Apply proper casing');
+    expect(print('[#42] capitalize subject')).toBe('[#42] Capitalize subject');
+  });
+
+  it('wraps overlong subject lines', () => {
+    const input = 'Wrap commit subject lines with more than 50 characters and insert one blank line before the remaining subject text. Wrap the remaining subject text to 72 characters.';
+    expect(print(input)).toMatchSnapshot();
+  });
+
+  it('wraps overlong body lines', () => {
+    const input = `Wrap body lines
+
+More detailed explanatory text is wrapped to 72 characters. The blank line separating the subject from the body is critical unless you omit the body entirely.
+    `;
+
+    expect(print(input)).toMatchSnapshot();
+  });
+
+  it('formats lists', () => {
+    const input = `Format lists in body
+
+* Bullet points are okay too
+* Typically a hyphen or asterisk is used for the bullet, followed by a
+single space, with blank lines in between, but conventions vary here
+* Use a hanging indent
+    `;
+
+    expect(print(input)).toMatchSnapshot();
+  });
+
+  it('strips leading and trailing blank lines and whitespace', () => {
+    const input = `
+
+  Remove whitespace around subject line  
+
+
+Also, remove additional blank lines before and after body.
+
+Preserve blank lines between paragraphs of the body.
+  
+Strip whitespace on empty lines (see line above).
+
+Strip trailing whitespace (see end of this line).  
+
+    `;
+
+    expect(print(input)).toMatchSnapshot();
+  });
+
+  it('strips body indentation', () => {
+    const input = `Strip body indentation
+
+      Unindent this line.
+      Move this one up.
+
+          function leave(me) {
+            return 'indented';
+          }
+
+      And continue.
+    `;
+
+    expect(print(input)).toMatchSnapshot();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8425,6 +8425,11 @@ prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
+prettier@^1.16.4:
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
+  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+
 pretty-error@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
@@ -9943,6 +9948,11 @@ strip-indent@^1.0.1:
   integrity sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
   dependencies:
     get-stdin "^4.0.1"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
 strip-json-comments@2.0.1, strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Pretty-print commit messages according to recommendations:
https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

This isn't yet applied to the generated commit messages.

My idea was to add a checkbox to the options (enabled by default) to apply the recommended format to generated commit messages.

Let me know what you think 💚 