### PR TITLE
[#144] Handle adapter errors (part 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react-router-dom": "5.0.0",
     "react-textarea-autosize": "^7.1.0",
     "speakingurl": "14.0.1",
+    "stacktrace-js": "^2.0.0",
     "strip-indent": "^2.0.0",
     "webextension-polyfill": "^0.4.0"
   }

--- a/src/common/popup/components/__snapshots__/error-details.test.jsx.snap
+++ b/src/common/popup/components/__snapshots__/error-details.test.jsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`error-details renders a button to copy the error details 1`] = `
+"Tickety-Tick revision: test-commit-hash
+
+\`\`\`
+Boom!
+    at scan (src/common/adapters/github.js:74:8)
+    at attempt (src/common/search.js:12:26)
+    at search (src/common/search.js:27:45)
+    at search (src/common/search.js:27:25)
+    at browser.runtime.onMessage.addListener (src/web-extension/content.js:8:13)
+    at wrappedSendResponse (node_modules/webextension-polyfill/dist/browser-polyfill.js:1057:-)
+\`\`\`"
+`;

--- a/src/common/popup/components/error-details.jsx
+++ b/src/common/popup/components/error-details.jsx
@@ -1,0 +1,65 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import StackTrace from 'stacktrace-js';
+
+import CopyButton from './copy-button';
+
+import ErrorShape from '../utils/error-shape';
+
+function framefmt(stackframe) {
+  const name = stackframe.getFunctionName() || '<anonymous>';
+  const file = stackframe.getFileName() || '-';
+  const line = stackframe.getLineNumber() || '-';
+  const column = stackframe.getColumnNumber() || '-';
+  return `    at ${name} (${file}:${line}:${column})`;
+}
+
+async function trace(error) {
+  const stackframes = await StackTrace.fromError(error); // parse and enhance with source maps
+  return [error.message, ...stackframes.map(framefmt)].join('\n');
+}
+
+class ErrorDetails extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      traces: null,
+    };
+  }
+
+  componentDidMount() {
+    const { errors } = this.props;
+
+    Promise.all(errors.map(trace))
+      .then(traces => this.setState({ traces }))
+      .catch(err => console.error(err));
+  }
+
+  render() {
+    const { traces } = this.state;
+
+    if (!traces) return null;
+
+    const preamble = `Tickety-Tick revision: ${COMMITHASH}`;
+    const logs = traces.map(tr => ['```', tr, '```'].join('\n'));
+
+    const info = [preamble, ...logs].join('\n\n');
+
+    return (
+      <CopyButton
+        className="btn btn-primary"
+        title="Copy error details to help identify the issue"
+        value={info}
+      >
+        Copy error details
+      </CopyButton>
+    );
+  }
+}
+
+ErrorDetails.propTypes = {
+  errors: PropTypes.arrayOf(ErrorShape.isRequired).isRequired,
+};
+
+export default ErrorDetails;

--- a/src/common/popup/components/error-details.test.jsx
+++ b/src/common/popup/components/error-details.test.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import StackTrace from 'stacktrace-js';
+
+import CopyErrorDetails from './error-details';
+import CopyButton from './copy-button';
+
+jest.mock('stacktrace-js', () => ({ fromError: jest.fn() }));
+
+class MockStackFrame {
+  constructor(functionName, fileName, lineNumber, columnNumber) {
+    this.functionName = functionName;
+    this.fileName = fileName;
+    this.lineNumber = lineNumber;
+    this.columnNumber = columnNumber;
+  }
+
+  getFunctionName() {
+    return this.functionName;
+  }
+
+  getFileName() {
+    return this.fileName;
+  }
+
+  getLineNumber() {
+    return this.lineNumber;
+  }
+
+  getColumnNumber() {
+    return this.columnNumber;
+  }
+}
+
+describe('error-details', () => {
+  function render(overrides) {
+    const defaults = { errors: [new Error('WAT?')] };
+    const props = { ...defaults, ...overrides };
+    return shallow(<CopyErrorDetails {...props} />);
+  }
+
+  beforeEach(() => {
+    StackTrace.fromError.mockResolvedValue([
+      ['scan', 'src/common/adapters/github.js', 74, 8],
+      ['attempt', 'src/common/search.js', 12, 26],
+      ['search', 'src/common/search.js', 27, 45],
+      ['search', 'src/common/search.js', 27, 25],
+      ['browser.runtime.onMessage.addListener', 'src/web-extension/content.js', 8, 13],
+      ['wrappedSendResponse', 'node_modules/webextension-polyfill/dist/browser-polyfill.js', 1057, null],
+    ].map(args => new MockStackFrame(...args)));
+  });
+
+  afterEach(() => {
+    StackTrace.fromError.mockClear();
+  });
+
+  it('renders a button to copy the error details', async () => {
+    const wrapper = render({ errors: [new Error('Boom!')] });
+    await new Promise(resolve => setTimeout(resolve, 0)); // wait for stacktrace-js processing
+    expect(wrapper.find(CopyButton).prop('value')).toMatchSnapshot();
+  });
+});

--- a/src/common/popup/components/no-tickets.jsx
+++ b/src/common/popup/components/no-tickets.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import ExternalLink from './external-link';
+import ErrorDetails from './error-details';
 
 import ErrorShape from '../utils/error-shape';
 
@@ -48,6 +49,9 @@ function Report({ errors }) {
         <br />
         while scanning for tickets.
       </p>
+      <p>
+        <ErrorDetails errors={errors} />
+      </p>
       <p className="pb-1">
         <IssueLink />
       </p>
@@ -68,7 +72,7 @@ function NoTickets({ errors }) {
 }
 
 NoTickets.propTypes = {
-  errors: PropTypes.arrayOf(ErrorShape).isRequired,
+  errors: PropTypes.arrayOf(ErrorShape.isRequired).isRequired,
 };
 
 export { Hint, Report };

--- a/src/common/popup/utils/error-shape.js
+++ b/src/common/popup/utils/error-shape.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 
 const ErrorShape = PropTypes.shape({
   message: PropTypes.string.isRequired,
+  stack: PropTypes.string,
 });
 
 export default ErrorShape;

--- a/src/common/utils/serializable-errors.js
+++ b/src/common/utils/serializable-errors.js
@@ -3,5 +3,6 @@
 export default function serializable(error) {
   return {
     message: error.message,
+    stack: error.stack,
   };
 }

--- a/src/common/utils/serializable-errors.test.js
+++ b/src/common/utils/serializable-errors.test.js
@@ -20,4 +20,8 @@ describe('serializable-errors', () => {
   it('includes the error message', () => {
     expect(representation.message).toBe(error.message);
   });
+
+  it('includes the error stack trace', () => {
+    expect(representation.stack).toBe(error.stack);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3760,6 +3760,13 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+error-stack-parser@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.2.tgz#4ae8dbaa2bf90a8b450707b9149dcabca135520d"
+  integrity sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==
+  dependencies:
+    stackframe "^1.0.4"
+
 es-abstract@^1.10.0, es-abstract@^1.4.3, es-abstract@^1.5.0, es-abstract@^1.7.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
@@ -10076,6 +10083,11 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
+
 source-map@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -10178,10 +10190,39 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
+stack-generator@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.3.tgz#bb74385c67ffc4ccf3c4dee5831832d4e509c8a0"
+  integrity sha512-kdzGoqrnqsMxOEuXsXyQTmvWXZmG0f3Ql2GDx5NtmZs59sT2Bt9Vdyq0XdtxUi58q/+nxtbF9KOQ9HkV1QznGg==
+  dependencies:
+    stackframe "^1.0.4"
+
 stack-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
+
+stackframe@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.0.4.tgz#357b24a992f9427cba6b545d96a14ed2cbca187b"
+  integrity sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==
+
+stacktrace-gps@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-3.0.2.tgz#33f8baa4467323ab2bd1816efa279942ba431ccc"
+  integrity sha512-9o+nWhiz5wFnrB3hBHs2PTyYrS60M1vvpSzHxwxnIbtY2q9Nt51hZvhrG1+2AxD374ecwyS+IUwfkHRE/2zuGg==
+  dependencies:
+    source-map "0.5.6"
+    stackframe "^1.0.4"
+
+stacktrace-js@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-2.0.0.tgz#776ca646a95bc6c6b2b90776536a7fc72c6ddb58"
+  integrity sha1-d2ymRqlbxsayuQd2U2p/xyxt21g=
+  dependencies:
+    error-stack-parser "^2.0.1"
+    stack-generator "^2.0.1"
+    stacktrace-gps "^3.0.1"
 
 static-extend@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
Here's an attempt at improving error reporting for adapter errors.

1. It uses the source-maps we ship with the bundled extension to create a clear stacktrace.
2. It allows users to easily copy the error message + stacktrace.

Ideally this makes it easier for users (including us) to provide more detailed issue descriptions.

![preview](https://user-images.githubusercontent.com/706519/59569305-fc99f680-9076-11e9-91e7-52460dd09367.gif)

To record this demo ☝️ I just inserted a `throw new Error('Boom!');` into the GitHub adapter.