### PR TITLE
Show version information in pop-up

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,9 @@
     "browser": true,
     "jest": true
   },
+  "globals": {
+    "COMMITHASH": "readonly"
+  },
   "plugins": [
     "jest"
   ],

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,9 @@
 module.exports = {
   coverageDirectory: 'coverage',
   collectCoverageFrom: ['<rootDir>/src/**/*.{js,jsx}'],
+  globals: {
+    COMMITHASH: 'test-commit-hash',
+  },
   setupFilesAfterEnv: ['<rootDir>/test/setup.js'],
   snapshotSerializers: ['enzyme-to-json/serializer'],
   transform: {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-jsx-a11y": "6.2.1",
     "eslint-plugin-react": "7.12.4",
     "file-loader": "^3.0.1",
+    "git-revision-webpack-plugin": "^3.0.3",
     "html-webpack-plugin": "3.2.0",
     "jest": "^24.5.0",
     "jest-junit": "^6.3.0",

--- a/src/common/popup/components/__snapshots__/about.test.jsx.snap
+++ b/src/common/popup/components/__snapshots__/about.test.jsx.snap
@@ -77,6 +77,16 @@ exports[`about renders 1`] = `
         <p
           className="small"
         >
+          <ExternalLink
+            href="https://github.com/bitcrowd/tickety-tick/tree/test-commit-hash"
+            title="Browse source code for this version"
+          >
+            test-commit-hash
+          </ExternalLink>
+        </p>
+        <p
+          className="small"
+        >
           <span>
             Logo by 
           </span>

--- a/src/common/popup/components/about.jsx
+++ b/src/common/popup/components/about.jsx
@@ -5,6 +5,9 @@ import ExternalLink from './external-link';
 
 import logo from '../../icons/icon-32.png';
 
+const repo = 'https://github.com/bitcrowd/tickety-tick';
+const tree = [repo, 'tree', COMMITHASH].join('/');
+
 function About() {
   return (
     <div>
@@ -45,8 +48,11 @@ function About() {
             </p>
             <p>
               <span>The source code is available on </span>
-              <ExternalLink href="https://github.com/bitcrowd/tickety-tick">GitHub</ExternalLink>
+              <ExternalLink href={repo}>GitHub</ExternalLink>
               .
+            </p>
+            <p className="small">
+              <ExternalLink href={tree} title="Browse source code for this version">{COMMITHASH}</ExternalLink>
             </p>
             <p className="small">
               <span>Logo by </span>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -2,8 +2,11 @@
 
 import path from 'path';
 
+import { DefinePlugin } from 'webpack';
+
 import CleanWebpackPlugin from 'clean-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
+import GitRevisionPlugin from 'git-revision-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import NotifierPlugin from 'webpack-build-notifier';
@@ -112,6 +115,17 @@ config.plugin('copy')
     },
   ], {
     copyUnmodified: true,
+  }]);
+
+const revision = new GitRevisionPlugin();
+
+config.plugin('revision')
+  .use(revision);
+
+config.plugin('define')
+  .after('revision')
+  .use(DefinePlugin, [{
+    COMMITHASH: JSON.stringify(revision.commithash()),
   }]);
 
 config.plugin('notifier')

--- a/yarn.lock
+++ b/yarn.lock
@@ -4548,6 +4548,11 @@ git-rev-sync@1.9.1:
     graceful-fs "4.1.11"
     shelljs "0.7.7"
 
+git-revision-webpack-plugin@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/git-revision-webpack-plugin/-/git-revision-webpack-plugin-3.0.3.tgz#f909949d7851d1039ed530518f73f5d46594e66f"
+  integrity sha512-B2ixM0fY7VgR61ZRSXYrh0R57Er7RY+CZb+fja5OFe21Y5o9GgzQanMgdlcBwWZ+LoOVqxBogbDutTTYMXQDWw==
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"


### PR DESCRIPTION
Display the Git commit hash on the pop-up info screen and link to the
repo tree for that commit of the extension.

![preview](https://user-images.githubusercontent.com/706519/57977914-9b3c2480-79f1-11e9-9492-e37fa975dca2.png)