### PR TITLE
[#178] Automate release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,14 +44,64 @@ jobs:
             JEST_JUNIT_OUTPUT: reports/jest/results.xml
       - store_test_results:
           path: reports
+  bundle:
+    <<: *base
+    steps:
+      - restore_cache:
+          key: repo-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: "Bundle all"
+          command: "yarn bundle"
+      - persist_to_workspace:
+          root: ~/tickety-tick
+          paths:
+            - dist/release
+  publish-github-release:
+    docker:
+      - image: cibuilds/github:0.10
+    steps:
+      - attach_workspace:
+          at: ~/tickety-tick
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace -draft ${CIRCLE_TAG} ~/tickety-tick/dist/release
+
 workflows:
   version: 2
-  checks:
+  check_and_release:
     jobs:
-      - setup
+      - setup:
+          filters:
+            tags:
+              only: /^v.*/
       - lint:
           requires:
             - setup
+          filters:
+            tags:
+              only: /^v.*/
       - test:
           requires:
             - setup
+          filters:
+            tags:
+              only: /^v.*/
+      - bundle:
+          requires:
+            - setup
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - publish-github-release:
+          requires:
+            - bundle
+            - lint
+            - test
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/README.md
+++ b/README.md
@@ -147,14 +147,16 @@ Chrome Web Store and Firefox Add-ons require you to submit extensions as a singl
 yarn bundle:chrome
 yarn bundle:firefox
 ```
-You can also build a zip file for the safari extension to prepare for a release download on github with:
+
+You can also create a zip file for the Safari extension for a release on GitHub:
 
 ```shell
 yarn bundle:safari
 ```
 
-Or just run the following when you want to bundle everything:
-```
+Or just run the following to generate bundles for all browsers:
+
+```shell
 yarn bundle
 ```
 
@@ -169,9 +171,9 @@ yarn clean
 ### Releasing a new version
 
 1. Tick the version with [`yarn version`](https://yarnpkg.com/en/docs/cli/version) (creates a Git tag)
-2. push the tag that was created eg. `git push origin v3.0.0` (pushing all tags does not work)
-3. Wait till CircleCI publishes a draft release
-4. Edit draft release with in github, to include some changelog
+2. Push the tag that was created, e.g. `git push origin v3.0.0` ([pushing all tags does not currently work](https://support.circleci.com/hc/en-us/articles/115013854347-Jobs-builds-not-triggered-when-pushing-tag))
+3. Wait until CircleCI publishes a draft release
+4. Edit the draft release on GitHub to include additional information about the release
 5. Publish release in Chrome and Mozilla stores
 
 ## Insights

--- a/README.md
+++ b/README.md
@@ -169,12 +169,10 @@ yarn clean
 ### Releasing a new version
 
 1. Tick the version with [`yarn version`](https://yarnpkg.com/en/docs/cli/version) (creates a Git tag)
-2. Push the tag with `git push --tags`
-3. Do a `yarn clean`
-4. Build all bundles with `yarn bundle`
-5. Draft a [new release on GitHub](https://github.com/bitcrowd/tickety-tick/releases/new)
-6. Add package bundles to your new release
-7. Publish release in Chrome and Mozilla stores
+2. push the tag that was created eg. `git push origin v3.0.0` (pushing all tags does not work)
+3. Wait till CircleCI publishes a draft release
+4. Edit draft release with in github, to include some changelog
+5. Publish release in Chrome and Mozilla stores
 
 ## Insights
 

--- a/README.md
+++ b/README.md
@@ -147,15 +147,34 @@ Chrome Web Store and Firefox Add-ons require you to submit extensions as a singl
 yarn bundle:chrome
 yarn bundle:firefox
 ```
+You can also build a zip file for the safari extension to prepare for a release download on github with:
+
+```shell
+yarn bundle:safari
+```
+
+Or just run the following when you want to bundle everything:
+```
+yarn bundle
+```
+
+### Clean build folder
+
+To clean the output build path and delete the artifacts of the project use:
+
+```shell
+yarn clean
+```
 
 ### Releasing a new version
 
 1. Tick the version with [`yarn version`](https://yarnpkg.com/en/docs/cli/version) (creates a Git tag)
 2. Push the tag with `git push --tags`
-3. Build releases for Chrome, Firefox and Safari (see above)
-4. Draft a [new release on GitHub](https://github.com/bitcrowd/tickety-tick/releases/new)
-5. Add package bundles to your new release
-6. Publish release in Chrome and Mozilla stores
+3. Do a `yarn clean`
+4. Build all bundles with `yarn bundle`
+5. Draft a [new release on GitHub](https://github.com/bitcrowd/tickety-tick/releases/new)
+6. Add package bundles to your new release
+7. Publish release in Chrome and Mozilla stores
 
 ## Insights
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "bundle:chrome": "cross-env BUNDLE=true run-s build:chrome",
     "bundle:firefox": "cross-env BUNDLE=true run-s build:firefox",
     "bundle:safari": "cross-env BUNDLE=true run-s build:safari",
+    "bundle": "run-s -n bundle:chrome bundle:firefox bundle:safari",
     "lint": "eslint --ext .js,.jsx .",
     "test": "jest",
     "checks": "run-s lint test",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "jest",
     "checks": "run-s lint test",
     "clean": "rimraf dist",
-    "preversion": "./script/pre-version",
+    "preversion": "./script/list-changes > .VERSION_CHANGES",
     "postversion": "./script/post-version"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "open:firefox": "web-ext run --source-dir ./dist/firefox --pref startup.homepage_welcome_url=https://github.com/bitcrowd/tickety-tick",
     "bundle:chrome": "cross-env BUNDLE=true run-s build:chrome",
     "bundle:firefox": "cross-env BUNDLE=true run-s build:firefox",
+    "bundle:safari": "cross-env BUNDLE=true run-s build:safari",
     "lint": "eslint --ext .js,.jsx .",
     "test": "jest",
     "checks": "run-s lint test"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "bundle:safari": "cross-env BUNDLE=true run-s build:safari",
     "lint": "eslint --ext .js,.jsx .",
     "test": "jest",
-    "checks": "run-s lint test"
+    "checks": "run-s lint test",
+    "clean": "rimraf dist"
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",
@@ -56,6 +57,7 @@
     "postcss-loader": "3.0.0",
     "postcss-preset-env": "^6.7.0",
     "react-test-renderer": "16.8.6",
+    "rimraf": "^2.6.3",
     "sass-loader": "7.1.0",
     "web-ext": "3.1.0",
     "webpack": "4.35.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "lint": "eslint --ext .js,.jsx .",
     "test": "jest",
     "checks": "run-s lint test",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist",
+    "preversion": "./script/pre-version",
+    "postversion": "./script/post-version"
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",

--- a/script/list-changes
+++ b/script/list-changes
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Generate a list of changes between two versions,
+# e.g. to use in a `preversion` script as per:
+# https://yarnpkg.com/en/docs/cli/version
+#
+# Usage: script/list-changes [from-revision] [to-revision]
+#
+# For details on specifying git revisions, check out:
+# https://git-scm.com/docs/revisions
+#
+#
+# Examples:
+#
+#   script/list-changes
+#   script/list-changes master
+#   script/list-changes v3.0.0
+#   script/list-changes v2.0.0 v3.0.0
+#
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# To debug, uncomment:
+# set -o xtrace
+
+cd "$(dirname "$0")/.."
+
+pkgversion=$(node --print "require('./package.json').version")
+
+start="${1:-v$pkgversion}"
+end="${2:-HEAD}"
+
+exec git log --no-decorate --pretty='format:- %s (#%h)' "${start}..${end}"

--- a/script/post-version
+++ b/script/post-version
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+echo "v$npm_package_version\n" > .VERSION_ANNOTATION
+cat .VERSION_CHANGES >> .VERSION_ANNOTATION
+git tag -a v$npm_package_version -e -f -F .VERSION_ANNOTATION
+rm .VERSION_ANNOTATION .VERSION_CHANGES

--- a/script/pre-version
+++ b/script/pre-version
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-git log --no-decorate --pretty='format:- %s (#%h)' v$npm_package_version..HEAD > .VERSION_CHANGES

--- a/script/pre-version
+++ b/script/pre-version
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+git log --no-decorate --pretty='format:- %s (#%h)' v$npm_package_version..HEAD > .VERSION_CHANGES

--- a/webpack.safari.babel.js
+++ b/webpack.safari.babel.js
@@ -1,5 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
+import ZipWebpackPlugin from 'zip-webpack-plugin';
+
 import config, { src, dist } from './webpack.common';
 import pkg from './package.json';
 
@@ -10,7 +12,9 @@ config.entry('content').add(src.safari('content.js'));
 
 // Set browser-specific output path.
 
-config.output.path(dist('tickety-tick.safariextension'));
+const safariExtensionFolderName = 'tickety-tick.safariextension';
+
+config.output.path(dist(safariExtensionFolderName));
 
 // Copy Info.plist and Settings.plist in addition to the common files.
 
@@ -27,5 +31,15 @@ config.plugin('copy').tap(([patterns, options]) => [[
     from: src.safari('Settings.plist'),
   },
 ], options]);
+
+config.when(process.env.BUNDLE === 'true', cfg => cfg
+  .plugin('zip')
+  .use(ZipWebpackPlugin, [
+    {
+      path: dist(),
+      pathPrefix: safariExtensionFolderName,
+      filename: 'safari',
+    },
+  ]));
 
 export default config.toConfig();

--- a/webpack.safari.babel.js
+++ b/webpack.safari.babel.js
@@ -36,7 +36,7 @@ config.when(process.env.BUNDLE === 'true', cfg => cfg
   .plugin('zip')
   .use(ZipWebpackPlugin, [
     {
-      path: dist(),
+      path: dist('release'),
       pathPrefix: safariExtensionFolderName,
       filename: 'safari',
     },

--- a/webpack.webext.babel.js
+++ b/webpack.webext.babel.js
@@ -69,7 +69,7 @@ config.when(process.env.BUNDLE === 'true', cfg => cfg
   .plugin('zip')
   .use(ZipWebpackPlugin, [
     {
-      path: dist(),
+      path: dist('release'),
       filename: variant,
     },
   ]));


### PR DESCRIPTION
Fixes #178.

- [x] bundle task for Safari extension
- [x] clean task to clear the `dist` folder (nicer for manual release)
- [x] task to run all bundles similar to `yarn build`
- [x] put release bundles into separate folder, so all folder contents can be uploaded
- [x] automate release process in CircleCI build script (for tags
- [x] allows to annotate the tagged version and prefill with the history since the last version for `yarn version`