### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Tickety-Tick is available for every major browser:
 
 | Shortcut                       | Description                       |
 |--------------------------------|-----------------------------------|
-| <kbd>Ctrl</kbd> + <kbd>T</kbd> | Open the extension's popup dialog |
+| <kbd>Ctrl</kbd> + <kbd>t</kbd> | Open the extension's popup dialog |
 
 ## Building
 


### PR DESCRIPTION
Realized when #189 was merged, that we're actually telling people the wrong shortcut 🙈

It's not <kbd>T</kbd> but <kbd>t</kbd> of course 🤦‍♂ 