### PR TITLE
[#195] Support backlog & board view of JIRA next gen software projects

### DIFF
--- a/src/common/adapters/jira.js
+++ b/src/common/adapters/jira.js
@@ -19,11 +19,7 @@ function isJiraPage(loc, doc) {
   return false;
 }
 
-const pathSuffixes = new RegExp(
-  "/(browse/[^/]+|projects/[^/]+/issues/[^/]+|secure/RapidBoard.jspa)|(jira/software/projects/[^/]+/boards/[^/]+/)$",
-  "g"
-);
-
+const pathSuffixes = new RegExp("/(browse/[^/]+|projects/[^/]+/issues/[^/]+|secure/RapidBoard.jspa|jira/software/projects/[^/]+/boards/[^/]+/)$", "g");
 function getPathPrefix(loc) {
   return loc.pathname.replace(pathSuffixes, "");
 }
@@ -35,15 +31,15 @@ function getSelectedIssueId(loc, prefix = "") {
 
   const path = loc.pathname.substr(prefix.length); // strip path prefix
 
-  return ["/projects/:project/issues/:id", "/browse/:id"]
-    .map(pattern => match(pattern, path).id)
-    .find(Boolean);
+  return (["/projects/:project/issues/:id", "/browse/:id"]
+    .map((pattern) => match(pattern, path).id)
+    .find(Boolean));
 }
 
 function extractTicketInfo(response) {
   const {
     key: id,
-    fields: { issuetype, summary: title }
+    fields: { issuetype, summary: title },
   } = response;
   const type = issuetype.name.toLowerCase();
   return { id, title, type };

--- a/src/common/adapters/jira.js
+++ b/src/common/adapters/jira.js
@@ -9,29 +9,29 @@
 // * Issues and filters: https://<YOUR-SUBDOMAIN>.atlassian.net/projects/<PROJECT-KEY>/issues/<ISSUE-KEY>
 // * Issue view: https://<YOUR-SUBDOMAIN>.atlassian.net/browse/<ISSUE-KEY>
 
-import { match } from "micro-match";
+import { match } from 'micro-match';
 
-import client from "../client";
+import client from '../client';
 
 function isJiraPage(loc, doc) {
-  if (loc.host.endsWith(".atlassian.net")) return true;
-  if (doc.body.id === "jira") return true; // self-managed instance on different domain
+  if (loc.host.endsWith('.atlassian.net')) return true;
+  if (doc.body.id === 'jira') return true; // self-managed instance on different domain
   return false;
 }
 
-const pathSuffixes = new RegExp("/(browse/[^/]+|projects/[^/]+/issues/[^/]+|secure/RapidBoard.jspa|jira/software/projects/[^/]+/boards/[^/]+/)$", "g");
+const pathSuffixes = new RegExp('/(browse/[^/]+|projects/[^/]+/issues/[^/]+|secure/RapidBoard.jspa|jira/software/projects/[^/]+/boards/[^/]+/)$', 'g');
 function getPathPrefix(loc) {
-  return loc.pathname.replace(pathSuffixes, "");
+  return loc.pathname.replace(pathSuffixes, '');
 }
 
-function getSelectedIssueId(loc, prefix = "") {
+function getSelectedIssueId(loc, prefix = '') {
   const { searchParams: params } = new URL(loc.href);
 
-  if (params.has("selectedIssue")) return params.get("selectedIssue");
+  if (params.has('selectedIssue')) return params.get('selectedIssue');
 
   const path = loc.pathname.substr(prefix.length); // strip path prefix
 
-  return (["/projects/:project/issues/:id", "/browse/:id"]
+  return (['/projects/:project/issues/:id', '/browse/:id']
     .map((pattern) => match(pattern, path).id)
     .find(Boolean));
 }

--- a/src/common/adapters/jira.js
+++ b/src/common/adapters/jira.js
@@ -19,7 +19,7 @@ function isJiraPage(loc, doc) {
   return false;
 }
 
-const pathSuffixes = new RegExp('/(browse/[^/]+|projects/[^/]+/issues/[^/]+|secure/RapidBoard.jspa)$', 'g');
+const pathSuffixes = new RegExp('/(browse/[^/]+|projects/[^/]+/issues/[^/]+|secure/RapidBoard.jspa)|(jira/software/projects/[^/]+/boards/[^/]+/)$', 'g');
 
 function getPathPrefix(loc) {
   return loc.pathname.replace(pathSuffixes, '');

--- a/src/common/adapters/jira.test.js
+++ b/src/common/adapters/jira.test.js
@@ -76,6 +76,15 @@ describe('jira adapter', () => {
     expect(result).toEqual([ticket]);
   });
 
+
+  it('extracts tickets from new generation software projects', async () => {
+    const result = await scan(loc('my-subdomain.atlassian.net', `/jira/software/projects/TT/boards/8/backlog?selectedIssue=${key}`), doc);
+
+    expect(api.get).toHaveBeenCalledWith(`issue/${key}`);
+    expect(result).toEqual([ticket]);
+  });
+
+
   it('extracts tickets on self-managed instances', async () => {
     const result = await scan(loc('jira.local', `/browse/${key}`), doc);
     expect(client).toHaveBeenCalledWith('https://jira.local/rest/api/latest');
@@ -97,4 +106,6 @@ describe('jira adapter', () => {
 
     expect(results).toEqual([[ticket], [ticket], [ticket]]);
   });
+
+
 });

--- a/src/common/adapters/jira.test.js
+++ b/src/common/adapters/jira.test.js
@@ -78,7 +78,7 @@ describe('jira adapter', () => {
 
 
   it('extracts tickets from new generation software projects', async () => {
-    const result = await scan(loc('my-subdomain.atlassian.net', `/jira/software/projects/TT/boards/8/backlog?selectedIssue=${key}`), doc);
+    const result = await scan(loc('my-subdomain.atlassian.net', '/jira/software/projects/TT/boards/8/backlog', `?selectedIssue=${key}`), doc);
 
     expect(api.get).toHaveBeenCalledWith(`issue/${key}`);
     expect(result).toEqual([ticket]);

--- a/src/common/adapters/jira.test.js
+++ b/src/common/adapters/jira.test.js
@@ -106,6 +106,4 @@ describe('jira adapter', () => {
 
     expect(results).toEqual([[ticket], [ticket], [ticket]]);
   });
-
-
 });

--- a/src/common/adapters/jira.test.js
+++ b/src/common/adapters/jira.test.js
@@ -79,7 +79,6 @@ describe('jira adapter', () => {
 
   it('extracts tickets from new generation software projects', async () => {
     const result = await scan(loc('my-subdomain.atlassian.net', '/jira/software/projects/TT/boards/8/backlog', `?selectedIssue=${key}`), doc);
-
     expect(api.get).toHaveBeenCalledWith(`issue/${key}`);
     expect(result).toEqual([ticket]);
   });


### PR DESCRIPTION
Add next gen project url structure to regex of known url suffixes. These URLs look like this:

https://bitcrowd.atlassian.net/jira/software/projects/BCHP/boards/7?selectedIssue=BCHP-149

This fixes #195 

TODO:
- [x] add a test for this kind of path in `jira.test.js`