### PR TITLE
Update authors to be all of us

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.2.0",
   "name": "tickety-tick",
   "description": "A browser extension that helps you to create commit messages and branch names from story trackers.",
-  "author": "Developers of bitcrowd.net <tickety-tick@bitcrowd.net>",
+  "author": "bitcrowd <tickety-tick@bitcrowd.net>",
   "license": "MIT",
   "scripts": {
     "build": "run-s -n build:chrome build:firefox build:safari",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.2.0",
   "name": "tickety-tick",
   "description": "A browser extension that helps you to create commit messages and branch names from story trackers.",
-  "author": "Bodo Tasche <bodo@bitcrowd.net>",
+  "author": "Developers of bitcrowd.net <tickety-tick@bitcrowd.net>",
   "license": "MIT",
   "scripts": {
     "build": "run-s -n build:chrome build:firefox build:safari",


### PR DESCRIPTION
Since bodo os not working at bitcrowd anymore, the mail address was out of date in package.json. This changes it to our tickety-tick address we use to register with the addon stores. Also it does not refer to a specific person anymore but all bitcrowd devs.