### PR TITLE
[#195] Support backlog & board view of JIRA next…

### DIFF
--- a/src/common/adapters/jira.js
+++ b/src/common/adapters/jira.js
@@ -19,7 +19,7 @@ function isJiraPage(loc, doc) {
   return false;
 }
 
-const pathSuffixes = new RegExp('/(browse/[^/]+|projects/[^/]+/issues/[^/]+|secure/RapidBoard.jspa|jira/software/projects/[^/]+/boards/[^/]+/)$', 'g');
+const pathSuffixes = new RegExp('/(browse/[^/]+|projects/[^/]+/issues/[^/]+|secure/RapidBoard.jspa|jira/software/projects/[^/]+/boards/[^/]+/?)$', 'g');
 function getPathPrefix(loc) {
   return loc.pathname.replace(pathSuffixes, '');
 }

--- a/src/safari-extension/content.js
+++ b/src/safari-extension/content.js
@@ -5,8 +5,8 @@ import stdsearch from '../common/search';
 function onMessage(event) {
   if (window.top === window) {
     if (event.name === 'get-tickets') {
-      stdsearch(window.location, document).then((tickets) => {
-        safari.self.tab.dispatchMessage('tickets', tickets);
+      stdsearch(window.location, document).then((results) => {
+        safari.self.tab.dispatchMessage('tickets', results);
       });
     }
   }


### PR DESCRIPTION
…gen software projects.

Closes #195.
Might also fix #214.

The Jira path RegExp was not matching and thus the requested API URL was not constructed correctly, i.e. we got:

```
https://bitcrowd.atlassian.net/jira/software/projects/BCHP/boards/7/rest/api/latest/issue/BCHP-211
```

instead of

```
https://bitcrowd.atlassian.net/rest/api/latest/issue/BCHP-211
```

**TODO:** Add a test case