### PR TITLE
Update config for html-webpack-plugin

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -101,6 +101,7 @@ config.plugin('html').use(HtmlWebpackPlugin, [
       collapseWhitespace: true,
       removeScriptTypeAttributes: true,
     },
+    cache: false,
   },
 ]);
 

--- a/webpack.webext.babel.js
+++ b/webpack.webext.babel.js
@@ -34,6 +34,7 @@ config.plugin('options-html').use(HtmlWebpackPlugin, [
       collapseWhitespace: true,
       removeScriptTypeAttributes: true,
     },
+    cache: false,
   },
 ]);
 


### PR DESCRIPTION
Set the cache option to false.

With the update to v4, the plugin otherwise won't re-generate our two
HTML files (popup and options) when in watch mode.