### PR TITLE
[#163] Please add notion.so support :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Currently, we support:
 - [GitHub](https://github.com/)
 - [GitLab](https://gitlab.com/)
 - [Jira](https://www.atlassian.com/software/jira)
-- [Trello](https://trello.com/)
 - [Notion](https://www.notion.so/)
+- [Trello](https://trello.com/)
 
 Your ticket system is missing? Go ahead and implement an adapter for it! We are always happy about contributions and here to support you 👋.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Currently, we support:
 - [GitLab](https://gitlab.com/)
 - [Jira](https://www.atlassian.com/software/jira)
 - [Trello](https://trello.com/)
+- [Notion](https://www.notion.so/)
 
 Your ticket system is missing? Go ahead and implement an adapter for it! We are always happy about contributions and here to support you 👋.
 

--- a/src/common/adapters/notion.js
+++ b/src/common/adapters/notion.js
@@ -54,9 +54,11 @@ function extractTicketInfo(result) {
   return { id, title, type };
 }
 
-function getTickets(response) {
-  const { results = [] } = response;
-  return results.map(extractTicketInfo).filter(Boolean);
+function getTickets(response, id) {
+  return (response.results || [])
+    .map(extractTicketInfo)
+    .filter(Boolean)
+    .filter((t) => t.id === id);
 }
 
 async function scan(loc) {
@@ -70,7 +72,7 @@ async function scan(loc) {
   const request = { json: { requests: [{ table: 'block', id }] } };
   const response = await api.post('api/v3/getRecordValues', request).json();
 
-  return getTickets(response);
+  return getTickets(response, id);
 }
 
 export default scan;

--- a/src/common/adapters/notion.js
+++ b/src/common/adapters/notion.js
@@ -14,16 +14,16 @@ import { match } from 'micro-match';
 import client from '../client';
 
 /**
- * Turns a page ID without dashes into a dasherized RFC 4122 UUID.
+ * Turns a slugged page ID without dashes into a dasherized RFC 4122 UUID.
  * UUID-Format: 96ec637d-e4b0-4a5e-acf3-8d4d9a1b2e4b
  */
-function uuid(string) {
+function uuid(slugId) {
   return [
-    string.substring(0, 8),
-    string.substring(8, 12),
-    string.substring(12, 16),
-    string.substring(16, 20),
-    string.substring(20),
+    slugId.substring(0, 8),
+    slugId.substring(8, 12),
+    slugId.substring(12, 16),
+    slugId.substring(16, 20),
+    slugId.substring(20),
   ].join('-');
 }
 
@@ -37,10 +37,10 @@ function getPageFromPath(path) {
 function getSelectedPageId(loc) {
   const { pathname: path, searchParams: params } = new URL(loc.href);
   const isPageModal = params.has('p');
-  const id = isPageModal ? params.get('p') : getPageFromPath(path);
+  const slugId = isPageModal ? params.get('p') : getPageFromPath(path);
 
-  if (!id) return null;
-  return uuid(id);
+  if (!slugId) return null;
+  return uuid(slugId);
 }
 
 function extractTicketInfo(result) {

--- a/src/common/adapters/notion.js
+++ b/src/common/adapters/notion.js
@@ -1,0 +1,76 @@
+/**
+ * notion.so adapter
+ *
+ * The adapter extracts the UUID of a selected notion.so task ("page") from the
+ * page URL and uses the notion.so API to retrieve the corresponding task
+ * information.
+ *
+ * Note: this adapter uses notion.so's internal v3 API as there is no public
+ * API yet.
+ */
+
+import { match } from 'micro-match';
+
+import client from '../client';
+
+/**
+ * Turns a page ID without dashes into a dasherized RFC 4122 UUID.
+ * UUID-Format: 96ec637d-e4b0-4a5e-acf3-8d4d9a1b2e4b
+ */
+function uuid(string) {
+  return [
+    string.substring(0, 8),
+    string.substring(8, 12),
+    string.substring(12, 16),
+    string.substring(16, 20),
+    string.substring(20),
+  ].join('-');
+}
+
+function getPageFromPath(path) {
+  const { slug } = match('/:organization/:slug', path);
+  if (!slug) return null;
+
+  return slug.replace(/.*-/, ''); // strip title from slug
+}
+
+function getSelectedPageId(loc) {
+  const { pathname: path, searchParams: params } = new URL(loc.href);
+  const isPageModal = params.has('p');
+  const id = isPageModal ? params.get('p') : getPageFromPath(path);
+
+  if (!id) return null;
+  return uuid(id);
+}
+
+function extractTicketInfo(result) {
+  const { value } = result;
+  if (!value) return null;
+
+  const { id, type } = value;
+  if (type !== 'page') return null;
+
+  const title = value.properties.title[0][0];
+  return { id, title, type };
+}
+
+function getTickets(response) {
+  const { results = [] } = response;
+  return results.map(extractTicketInfo).filter(Boolean);
+}
+
+async function scan(loc) {
+  if (loc.host !== 'www.notion.so') return [];
+
+  const id = getSelectedPageId(loc);
+
+  if (!id) return [];
+
+  const api = client(`https://${loc.host}`);
+  const request = { json: { requests: [{ table: 'block', id }] } };
+  const response = await api.post('api/v3/getRecordValues', request).json();
+
+  return getTickets(response);
+}
+
+export default scan;

--- a/src/common/adapters/notion.test.js
+++ b/src/common/adapters/notion.test.js
@@ -85,6 +85,22 @@ describe('notion adapter', () => {
     expect(result).toEqual([]);
   });
 
+  it('returns an empty one if the page id does not match the requested one', async () => {
+    const otherId = '7c1e7ee7-9107-4890-b2ec-83175b8edv99';
+    const otherSlugId = otherId.replace(/-/g, '');
+
+    const location = loc(
+      'www.notion.so',
+      `/notionuser/Some-ticket-${otherSlugId}`
+    );
+    const result = await scan(location);
+    const request = { requests: [{ table: 'block', id: otherId }] };
+    expect(api.post).toHaveBeenCalledWith('api/v3/getRecordValues', {
+      json: request,
+    });
+    expect(result).toEqual([]);
+  });
+
   it('extracts tickets from page modals (board view)', async () => {
     const location = loc(
       'www.notion.so',

--- a/src/common/adapters/notion.test.js
+++ b/src/common/adapters/notion.test.js
@@ -85,7 +85,7 @@ describe('notion adapter', () => {
     expect(result).toEqual([]);
   });
 
-  it('returns an empty one if the page id does not match the requested one', async () => {
+  it('returns an empty array if the page id does not match the requested one', async () => {
     const otherId = '7c1e7ee7-9107-4890-b2ec-83175b8edv99';
     const otherSlugId = otherId.replace(/-/g, '');
 

--- a/src/common/adapters/notion.test.js
+++ b/src/common/adapters/notion.test.js
@@ -1,0 +1,111 @@
+import client from '../client';
+import loc from './__helpers__/location';
+import scan from './notion';
+
+jest.mock('../client', () => jest.fn());
+
+describe('notion adapter', () => {
+  const id = '5b1d7dd7-9107-4890-b2ec-83175b8eda83';
+  const title = 'Add notion.so support';
+  const slugId = '5b1d7dd791074890b2ec83175b8eda83';
+  const slug = `Add-notion-so-support-${slugId}`;
+  const response = {
+    results: [
+      {
+        role: 'editor',
+        value: {
+          id,
+          type: 'page',
+          properties: { title: [[title]] },
+        },
+      },
+    ],
+  };
+
+  const ticket = { id, title, type: 'page' };
+  const api = { post: jest.fn() };
+
+  beforeEach(() => {
+    api.post.mockReturnValue({ json: () => response });
+    client.mockReturnValue(api);
+  });
+
+  afterEach(() => {
+    api.post.mockReset();
+    client.mockReset();
+  });
+
+  it('returns an empty array when not on a www.notion.so page', async () => {
+    const result = await scan(loc('another-domain.com'));
+    expect(api.post).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('uses the notion.so api', async () => {
+    const location = loc('www.notion.so', `/notionuser/${slug}`);
+    await scan(location);
+    expect(client).toHaveBeenCalledWith('https://www.notion.so');
+    expect(api.post).toHaveBeenCalled();
+  });
+
+  it('returns an empty array when the current page is a board view', async () => {
+    const res = {
+      results: [
+        {
+          role: 'editor',
+          value: { id, type: 'collection_view_page' },
+        },
+      ],
+    };
+    api.post.mockReturnValueOnce({ json: () => res });
+
+    const location = loc(
+      'www.notion.so',
+      `/notionuser/${slugId}`,
+      '?v=77ff97cab6ff4beab7fa6e27f992dd5e'
+    );
+    const result = await scan(location);
+    const request = { requests: [{ table: 'block', id }] };
+    expect(api.post).toHaveBeenCalledWith('api/v3/getRecordValues', {
+      json: request,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('returns an emtpy array when the page does not exist', async () => {
+    const res = { results: [{ role: 'editor' }] };
+    api.post.mockReturnValueOnce({ json: () => res });
+
+    const location = loc('www.notion.so', `/notionuser/${slug}`);
+    const result = await scan(location);
+    const request = { requests: [{ table: 'block', id }] };
+    expect(api.post).toHaveBeenCalledWith('api/v3/getRecordValues', {
+      json: request,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('extracts tickets from page modals (board view)', async () => {
+    const location = loc(
+      'www.notion.so',
+      '/notionuser/0e8608aa770a4d36a246d7a3c64f51af',
+      `?v=77ff97cab6ff4beab7fa6e27f992dd5e&p=${slugId}`
+    );
+    const result = await scan(location);
+    const request = { requests: [{ table: 'block', id }] };
+    expect(api.post).toHaveBeenCalledWith('api/v3/getRecordValues', {
+      json: request,
+    });
+    expect(result).toEqual([ticket]);
+  });
+
+  it('extracts tickets from the page view', async () => {
+    const location = loc('www.notion.so', `/notionuser/${slug}`);
+    const result = await scan(location);
+    const request = { requests: [{ table: 'block', id }] };
+    expect(api.post).toHaveBeenCalledWith('api/v3/getRecordValues', {
+      json: request,
+    });
+    expect(result).toEqual([ticket]);
+  });
+});

--- a/src/common/popup/components/no-tickets.jsx
+++ b/src/common/popup/components/no-tickets.jsx
@@ -21,7 +21,7 @@ function Hint() {
       <p>
         Tickety-Tick currently supports
         <br />
-        GitHub, GitLab, Jira and Trello.
+        GitHub, GitLab, Jira, Trello and Notion.
       </p>
       <h6>Missing anything or found a bug?</h6>
       <p className="pb-1">

--- a/src/common/search.js
+++ b/src/common/search.js
@@ -30,6 +30,6 @@ export async function search(adapters, loc, doc) {
   return aggregate(results);
 }
 
-export const stdadapters = [Notion, GitHub, GitLab, Jira, Trello];
+export const stdadapters = [GitHub, GitLab, Jira, Trello, Notion];
 
 export default search.bind(null, stdadapters);

--- a/src/common/search.js
+++ b/src/common/search.js
@@ -1,6 +1,7 @@
 import GitHub from './adapters/github';
 import GitLab from './adapters/gitlab';
 import Jira from './adapters/jira';
+import Notion from './adapters/notion';
 import Trello from './adapters/trello';
 import serializable from './utils/serializable-errors';
 
@@ -29,6 +30,6 @@ export async function search(adapters, loc, doc) {
   return aggregate(results);
 }
 
-export const stdadapters = [GitHub, GitLab, Jira, Trello];
+export const stdadapters = [Notion, GitHub, GitLab, Jira, Trello];
 
 export default search.bind(null, stdadapters);

--- a/src/common/search.js
+++ b/src/common/search.js
@@ -30,6 +30,6 @@ export async function search(adapters, loc, doc) {
   return aggregate(results);
 }
 
-export const stdadapters = [GitHub, GitLab, Jira, Trello, Notion];
+export const stdadapters = [GitHub, GitLab, Jira, Notion, Trello];
 
 export default search.bind(null, stdadapters);


### PR DESCRIPTION
This adds support for the [Notion](www.notion.so) tracker as beautifully prepared by @pmeinhardt in #163 🙏 💚 

Notion does not differentiate between "stories", "tasks", etc. For them, all actionable entites are **"pages"**. Tickety-Tick therefore also support creating branch names and commit messages for pages.

See here in action👇 

![notion-small](https://user-images.githubusercontent.com/3491815/79379794-bac03200-7f5f-11ea-9e28-5a7307426a29.gif)

Please note: the board view is not an actionable "page" and therefore not supported by Tickety-Tick 🧑‍🏫 .

The commit messages for now only have a subject containing the rather long ID of the page and its title. For the page from the screencast this is:

**branch**

```
page/5b1d7dd7-9107-4890-b2ec-83175b8eda83-add-image-block
```

**message**

```
[#5b1d7dd7-9107-4890-b2ec-83175b8eda83] Add image…

…block
```

**command**

```
git checkout -b 'page/5b1d7dd7-9107-4890-b2ec-83175b8eda83-add-image-block' && git commit --allow-empty -m '[#5b1d7dd7-9107-4890-b2ec-83175b8eda83] Add image…

…block
'
```