### PR TITLE
[#228] Add debugging hints to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ yarn open:firefox
 
 You can run both `watch:[browser]` and `open:[browser]` scripts in parallel to automatically rebuild and reload the extension as you make changes.
 
+#### Tips & Tricks 🎩
+
+Use the Firefox developer tools to [debug the extension](https://extensionworkshop.com/documentation/develop/debugging/).
+
 ### Running automated checks
 
 To execute the automated source code checks, run:


### PR DESCRIPTION
Add link to the docs for using Firefox' developer tools for debugging
extensions.

closes #228