### PR TITLE
[#230] Fix loading animation in new design

### DIFF
--- a/src/common/popup/styles/_spinner.scss
+++ b/src/common/popup/styles/_spinner.scss
@@ -1,5 +1,5 @@
 .spinner {
-  margin: 4rem auto 0;
+  margin: 2rem auto 2rem;
   width: 4rem;
   text-align: center;
 }
@@ -32,11 +32,11 @@
 }
 
 @keyframes spinner-bouncedelay {
-  0%, 80%, 100% { 
+  0%, 80%, 100% {
     -webkit-transform: scale(0);
     transform: scale(0);
   }
-  40% { 
+  40% {
     -webkit-transform: scale(1.0);
     transform: scale(1.0);
   }


### PR DESCRIPTION
This centers the spinner animation inside the popup window (see #230):

![loading](https://user-images.githubusercontent.com/3491815/80721696-d2bab880-8afe-11ea-9910-d97181c87d3c.gif)

Thanks to @pmeinhardt for pointing to these nifty debugging tools 🧙‍♂️ 