### PR TITLE
[#233] New helper to limit string length 

### DIFF
--- a/src/common/format/helpers.js
+++ b/src/common/format/helpers.js
@@ -1,8 +1,12 @@
 import { createSlug } from 'speakingurl';
 
-export const lowercase = (s) => s.toLowerCase();
-export const shellquote = (s) =>
+export const lowercase = () => (s) => s.toLowerCase();
+
+export const shellquote = () => (s) =>
   typeof s === 'string' ? `'${s.replace(/'/g, "'\\''")}'` : "''";
-export const slugify = createSlug({ separator: '-' });
-export const trim = (s) => s.replace(/^\s+|\s+$/g, '');
-export const uppercase = (s) => s.toUpperCase();
+
+export const slugify = () => createSlug({ separator: '-' });
+
+export const trim = () => (s) => s.trim();
+
+export const uppercase = () => (s) => s.toUpperCase();

--- a/src/common/format/helpers.js
+++ b/src/common/format/helpers.js
@@ -8,10 +8,12 @@ export const shellquote = () => (s) =>
 export const slugify = (separator = '-') => createSlug({ separator });
 
 export const substring = (...args) => (s) => s.substring(...args);
+substring.description = 'substring(start-index[, end-index])';
 
 export const trim = () => (s) => s.trim();
 
 export const truncate = (limit) => (s) =>
   s.length > limit ? `${s.substring(0, limit - 1)}…` : s;
+truncate.description = 'truncate(max-length)';
 
 export const uppercase = () => (s) => s.toUpperCase();

--- a/src/common/format/helpers.js
+++ b/src/common/format/helpers.js
@@ -5,8 +5,13 @@ export const lowercase = () => (s) => s.toLowerCase();
 export const shellquote = () => (s) =>
   typeof s === 'string' ? `'${s.replace(/'/g, "'\\''")}'` : "''";
 
-export const slugify = () => createSlug({ separator: '-' });
+export const slugify = (separator = '-') => createSlug({ separator });
+
+export const substring = (...args) => (s) => s.substring(...args);
 
 export const trim = () => (s) => s.trim();
+
+export const truncate = (limit) => (s) =>
+  s.length > limit ? `${s.substring(0, limit - 1)}…` : s;
 
 export const uppercase = () => (s) => s.toUpperCase();

--- a/src/common/format/helpers.test.js
+++ b/src/common/format/helpers.test.js
@@ -70,6 +70,19 @@ describe('format helpers', () => {
       const formatted = slugify('##23 #hashtag');
       expect(formatted).toBe('23-hashtag');
     });
+
+    it('accepts a custom separator', () => {
+      const formatted = helpers.slugify('_')('##23 #hashtag');
+      expect(formatted).toBe('23_hashtag');
+    });
+  });
+
+  describe('substring', () => {
+    const substring = helpers.substring(3, 6);
+
+    it('returns the specified slice of a string', () => {
+      expect(substring('abcdefghi')).toBe('def');
+    });
   });
 
   describe('trim', () => {
@@ -77,6 +90,18 @@ describe('format helpers', () => {
 
     it('removes leading and trailing whitespace', () => {
       expect(trim('\t  black\t\t  ')).toBe('black');
+    });
+  });
+
+  describe('truncate', () => {
+    const truncate = helpers.truncate(3);
+
+    it('truncates strings longer than the limit', () => {
+      expect(truncate('abcd')).toBe('ab…');
+    });
+
+    it('returns short strings unchanged', () => {
+      expect(truncate('abc')).toBe('abc');
     });
   });
 

--- a/src/common/format/helpers.test.js
+++ b/src/common/format/helpers.test.js
@@ -2,7 +2,7 @@ import * as helpers from './helpers';
 
 describe('format helpers', () => {
   describe('lowercase', () => {
-    const { lowercase } = helpers;
+    const lowercase = helpers.lowercase();
 
     it('lowercases strings', () => {
       expect(lowercase('QUIET')).toBe('quiet');
@@ -10,7 +10,7 @@ describe('format helpers', () => {
   });
 
   describe('shellquote', () => {
-    const { shellquote } = helpers;
+    const shellquote = helpers.shellquote();
 
     it('wraps the input in single-quotes', () => {
       expect(shellquote('echo "pwned"')).toBe('\'echo "pwned"\'');
@@ -24,7 +24,7 @@ describe('format helpers', () => {
   });
 
   describe('slugify', () => {
-    const { slugify } = helpers;
+    const slugify = helpers.slugify();
 
     it('formats normal strings', () => {
       const formatted = slugify('hello');
@@ -73,7 +73,7 @@ describe('format helpers', () => {
   });
 
   describe('trim', () => {
-    const { trim } = helpers;
+    const trim = helpers.trim();
 
     it('removes leading and trailing whitespace', () => {
       expect(trim('\t  black\t\t  ')).toBe('black');
@@ -81,7 +81,7 @@ describe('format helpers', () => {
   });
 
   describe('uppercase', () => {
-    const { uppercase } = helpers;
+    const uppercase = helpers.uppercase();
 
     it('uppercases strings', () => {
       expect(uppercase('loud')).toBe('LOUD');

--- a/src/common/format/index.test.js
+++ b/src/common/format/index.test.js
@@ -25,7 +25,7 @@ describe('ticket formatting', () => {
     });
 
     describe('branch', () => {
-      const { slugify } = helpers;
+      const slugify = helpers.slugify();
 
       it('includes ticket type, id and title', () => {
         const formatted = fmt.branch(ticket);
@@ -46,7 +46,7 @@ describe('ticket formatting', () => {
     });
 
     describe('command', () => {
-      const { shellquote } = helpers;
+      const shellquote = helpers.shellquote();
 
       it('includes the quoted branch name and commit message', () => {
         const branch = fmt.branch(ticket);

--- a/src/common/format/template.test.js
+++ b/src/common/format/template.test.js
@@ -8,49 +8,81 @@ describe('template', () => {
   });
 
   it('handles missing values', () => {
-    const transforms = { sparkle: (s) => `*${s}*` };
+    const transforms = { sparkle: () => (s) => `*${s}*` };
     const render = compile('--{nope | sparkle}', transforms);
     expect(render({})).toBe('--**');
     expect(render()).toBe('--**');
   });
 
   it('applies value transformations', () => {
-    const lowercase = jest.fn().mockImplementation((s) => s.toLowerCase());
-    const dasherize = jest
-      .fn()
-      .mockImplementation((s) => s.replace(/\s+/g, '-'));
-    const transforms = { lowercase, dasherize };
+    const lowercase = jest.fn((s) => s.toLowerCase());
+    const dasherize = jest.fn((s) => s.replace(/\s+/g, '-'));
 
-    const render = compile(
-      'result: {title | lowercase | dasherize}',
-      transforms
-    );
+    const transforms = {
+      lowercase: () => lowercase,
+      dasherize: () => dasherize,
+    };
+
+    const render = compile('= {title | lowercase | dasherize}', transforms);
     const output = render({ title: 'A B C' });
 
     expect(lowercase).toHaveBeenCalledWith('A B C');
     expect(dasherize).toHaveBeenCalledWith('a b c');
-    expect(output).toBe('result: a-b-c');
+    expect(output).toBe('= a-b-c');
+  });
+
+  it('supports parameterized transformations', () => {
+    const long = 'abcdefghijklmnopqrstuvwxyz';
+    const substring = (start, end) => (s) => s.substring(start, end);
+    const transforms = { substring };
+
+    const render = compile('pre {long | substring(15, 18)} post', transforms);
+    const output = render({ long });
+
+    expect(output).toBe('pre pqr post');
   });
 
   it('handles missing transformations', () => {
     const render = compile('a{a | ??}', {});
     const output = render({ a: '++' });
-    expect(output).toBe('a++');
+    expect(output).toBe('a!!(no helper named "??")');
+  });
+
+  it('handles invalid transformation parameters', () => {
+    const int = (s) => Number.parseInt(s, 10);
+    const pow = (exp) => (s) => int(s) ** int(exp);
+
+    const render = compile('{a | pow(break)}', { pow });
+    const output = render({ a: 12 });
+
+    expect(output).toBe('!!(invalid parameters provided to "pow": break)');
   });
 
   it('ignores whitespace within template expressions', () => {
-    const transforms = { triple: (a) => a * 3, square: (a) => a * a };
+    const transforms = {
+      triple: () => (a) => a * 3,
+      square: () => (a) => a * a,
+    };
+
     const render = compile(
       '({ a } * 3)**2 = {  a  |  triple  |  square  }',
       transforms
     );
     const output = render({ a: 2 });
+
     expect(output).toBe('(2 * 3)**2 = 36');
   });
 
-  it('handles incomplete template expressions', () => {
+  it('handles incomplete template expressions (no closing brace)', () => {
     const render = compile('{', {});
     const output = render({});
     expect(output).toBe('{');
+  });
+
+  it('handles incomplete template expressions (incomplete filter pipeline)', () => {
+    const trim = () => (s) => s.trim();
+    const render = compile('{a | trim |}', { trim });
+    const output = render({});
+    expect(output).toBe('!!(no helper named "undefined")');
   });
 });

--- a/src/web-extension/options/components/form.jsx
+++ b/src/web-extension/options/components/form.jsx
@@ -203,9 +203,10 @@ class Form extends Component {
               <ul className="list-unstyled text-muted">
                 {Object.keys(helpers)
                   .sort()
-                  .map((name) => (
-                    <li key={name}>{name}</li>
-                  ))}
+                  .map((name) => {
+                    const { description } = helpers[name];
+                    return <li key={name}>{description || name}</li>;
+                  })}
               </ul>
             </div>
           </div>

--- a/src/web-extension/options/components/form.test.jsx
+++ b/src/web-extension/options/components/form.test.jsx
@@ -150,12 +150,12 @@ describe('form', () => {
     );
   });
 
-  it('renders the names of available template helpers', () => {
+  it('renders the names & descriptions of available template helpers', () => {
     const wrapper = render({});
     const text = wrapper.text();
 
-    Object.keys(helpers).forEach((name) => {
-      expect(text).toContain(name);
+    Object.values(helpers).forEach((fn) => {
+      expect(text).toContain(fn.name || fn.description);
     });
   });
 


### PR DESCRIPTION
I was intrigued @bitboxer and had a moment this morning to throw something together.

It allows for (optionally) parameterized filters in templates, e.g.:

```
Title is "{value | truncate(50)}"
```

I've also changed how we handle errors in template expressions, hoping to make it easier to figure out what's going wrong in case of typos and erroneous templates. For instance:

- The above template will now return `Title is "!!(no helper named "truncate")"` if a `truncate` helper doesn't exist
- For a template `…{value | truncate(crash)}` it will return `…!!(invalid parameters provided to "truncate": crash)`

From what I can see, there's at least two more to-dos:

- [x] We need to slightly update the "helper" documentation on the Tickety-Tick options page to inform users about available parameters.
- [x] Update template code to not break on incomplete templates `{value | }`

Please take it for a spin when you have time.

Happy about feedback. 🙂 

Closes #233.

![preview](https://user-images.githubusercontent.com/706519/80799665-f8939c00-8b96-11ea-90a0-0f4264a4abf6.gif)
