### PR TITLE
[#212] Add 'sign' script and update Firefox docs

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,5 +9,5 @@ Offering a (beta-) version for download requires self-signing the add-on through
 Find the API credentials in 1Password and run:
 
 ```shell
-yarn build:firefox && yarn sign 
+WEB_EXT_API_KEY=xxx WEB_EXT_API_SECRET=xxx yarn build:firefox && yarn sign
 ```

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,8 +6,8 @@ Tips & tricks for maintainers of Tickety-Tick.
 
 Offering a (beta-) version for download requires self-signing the add-on through [addons.mozilla.org](https://extensionworkshop.com/documentation/publish/#distribute-your-signed-extension). This generates a `.xpi` for installing the extension in Firefox.
 
-Find the API credentials in 1password and run:
+Find the API credentials in 1Password and run:
 
-```
+```shell
 yarn build:firefox && yarn sign 
 ```

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,5 +9,5 @@ Offering a (beta-) version for download requires self-signing the add-on through
 Find the API credentials in 1Password and run:
 
 ```shell
-WEB_EXT_API_KEY=xxx WEB_EXT_API_SECRET=xxx yarn build:firefox && yarn sign
+yarn build:firefox && WEB_EXT_API_KEY=xxx WEB_EXT_API_SECRET=xxx yarn sign
 ```

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,13 @@
+# Maintainers 👔
+
+Tips & tricks for maintainers of Tickety-Tick.
+
+## Sign add-on for Firefox
+
+Offering a (beta-) version for download requires self-signing the add-on through [addons.mozilla.org](https://extensionworkshop.com/documentation/publish/#distribute-your-signed-extension). This generates a `.xpi` for installing the extension in Firefox.
+
+Find the API credentials in 1password and run:
+
+```
+yarn build:firefox && yarn sign 
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Tickety-Tick [![Build Status](https://circleci.com/gh/bitcrowd/tickety-tick.svg?style=svg)](https://circleci.com/gh/bitcrowd/tickety-tick)
+# ![ticket icon](./src/common/icons/icon-32.png) Tickety-Tick
+
+[![Build Status](https://circleci.com/gh/bitcrowd/tickety-tick.svg?style=svg)](https://circleci.com/gh/bitcrowd/tickety-tick)
 
 > #### How do you name this branch? What is the message for that commit?
 > A browser extension to generate these for you, based on the ticket you're working on.
@@ -86,7 +88,15 @@ Navigate to the [chrome://extensions](//chrome://extensions) page, enable "Devel
 
 If you just want to try out and debug the extension, go to [about:debugging#addons](//about:debugging#addons). Then press "Load Temporary Add-On" and select the built `manifest.json` from the `dist/firefox` extension directory.
 
-If you want to install this addon permanently, go to [about:addons](//about:addons) and click on the small cog icon. Select `Install Add-on From File...` and choose `dist/firefox`.
+If you want to install the extension permanently, you have two options:
+
+1. Install a self-signed add-on
+
+  Get a `tickety_tick-<version>.xpi` file from the [releases](https://github.com/bitcrowd/tickety-tick/releases) or [signing by a maintainer](./MAINTAINERS.md#sign-add-on-for-firefox). Then go to [about:addons](//about:addons), click on the small cog icon, select `Install Add-on From File...` and choose your `.xpi` file.
+
+2. Install an unsigned add-on
+
+  Enable [unsigned add-ons](https://support.mozilla.org/en-US/kb/add-on-signing-in-firefox#w_what-are-my-options-if-i-want-to-use-an-unsigned-add-on-advanced-users). Then go to [about:addons](//about:addons), click on the small cog icon, select `Install Add-on From File…` and choose `dist/firefox`.
 
 ### Opera
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you want to install the extension permanently, you have two options:
 
 1. Install a self-signed add-on
 
-  Get a `tickety_tick-<version>.xpi` file from the [releases](https://github.com/bitcrowd/tickety-tick/releases) or [signing by a maintainer](./MAINTAINERS.md#sign-add-on-for-firefox). Then go to [about:addons](//about:addons), click on the small cog icon, select `Install Add-on From File...` and choose your `.xpi` file.
+  Get a `tickety_tick-<version>.xpi` file from the [releases](https://github.com/bitcrowd/tickety-tick/releases) or sign a build yourself as per our [maintainer guide](./MAINTAINERS.md#sign-add-on-for-firefox). Then go to [about:addons](//about:addons), click on the small cog icon, select `Install Add-on From File…` and choose your `.xpi` file.
 
 2. Install an unsigned add-on
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,32 @@ Tickety-Tick is available for every major browser:
 - [Opera](./OPERA.md)
 - For Safari, you need to build it yourself ([see below](#safari))
 
+### Manual Installation
+
+Manually install the extension if you want to use an older version or a beta version.
+
+<details>
+<summary>Click here for instructions</summary>
+
+#### Chrome
+
+Download and unpack a `chrome.zip` file from the [releases](https://github.com/bitcrowd/tickety-tick/releases). Then navigate to the [chrome://extensions](//chrome://extensions) page, enable "Developer mode", press "Load unpacked extension" and point to the unpacked folder.
+
+#### Firefox
+
+Get a `tickety_tick-<version>.xpi` file from the [releases](https://github.com/bitcrowd/tickety-tick/releases) or sign a build yourself as per our [maintainer guide](./MAINTAINERS.md#sign-add-on-for-firefox). Then go to [about:addons](//about:addons), click on the small cog icon, select `Install Add-on From File…` and choose your `.xpi` file.
+
+#### Opera
+
+Download and unpack a `chrome.zip` file from the [releases](https://github.com/bitcrowd/tickety-tick/releases). Then navigate to the [opera://extensions](//opera://extensions) page, enable "Developer mode", press "Load unpacked extension" and point to the unpacked folder.
+</details>
+
 ## Keyboard Shortcuts
 
 | Shortcut                       | Description                       |
 |--------------------------------|-----------------------------------|
 | <kbd>Ctrl</kbd> + <kbd>t</kbd> | Open the extension's popup dialog |
+
 
 ## Building
 
@@ -88,15 +109,7 @@ Navigate to the [chrome://extensions](//chrome://extensions) page, enable "Devel
 
 If you just want to try out and debug the extension, go to [about:debugging#addons](//about:debugging#addons). Then press "Load Temporary Add-On" and select the built `manifest.json` from the `dist/firefox` extension directory.
 
-If you want to install the extension permanently, you have two options:
-
-1. Install a self-signed add-on
-
-  Get a `tickety_tick-<version>.xpi` file from the [releases](https://github.com/bitcrowd/tickety-tick/releases) or sign a build yourself as per our [maintainer guide](./MAINTAINERS.md#sign-add-on-for-firefox). Then go to [about:addons](//about:addons), click on the small cog icon, select `Install Add-on From File…` and choose your `.xpi` file.
-
-2. Install an unsigned add-on
-
-  Enable [unsigned add-ons](https://support.mozilla.org/en-US/kb/add-on-signing-in-firefox#w_what-are-my-options-if-i-want-to-use-an-unsigned-add-on-advanced-users). Then go to [about:addons](//about:addons), click on the small cog icon, select `Install Add-on From File…` and choose `dist/firefox`.
+If you want to install the extension permanently, you need to [enable unsigned add-ons](https://support.mozilla.org/en-US/kb/add-on-signing-in-firefox#w_what-are-my-options-if-i-want-to-use-an-unsigned-add-on-advanced-users). Then go to [about:addons](//about:addons), click on the small cog icon, select `Install Add-on From File…` and choose `dist/firefox`.
 
 ### Opera
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "open:firefox": "web-ext run --source-dir ./dist/firefox --pref startup.homepage_welcome_url=https://github.com/bitcrowd/tickety-tick",
     "bundle:chrome": "cross-env BUNDLE=true run-s build:chrome",
     "bundle:firefox": "cross-env BUNDLE=true run-s build:firefox",
+    "sign": "web-ext sign --source-dir ./dist/firefox --artifacts-dir ./dist --channel=unlisted",
     "lint": "eslint --ignore-path .gitignore --ext .js,.jsx .",
     "test": "jest",
     "checks": "run-s lint test"


### PR DESCRIPTION
This addresses #212: Firefox by default does no longer allow to permanently install unsigned extensions.

Therefore, I added a `yarn sign` script for self-signing "unlisted" beta version of the extension via `web-ext` (we will most likely run this from CI in the future). According to the docs and experience on the internet, the `sign` command is not yet ready for _"listed"_ extensions. It may be possible to to both though: submit the same version as "listed" and "unlisted". We probably want to do this if we _(what I would suggest)_ also want to give people the option install the extension from a file.

I also updated the docs on that topic and will update the instructions in 1password in a minute.