### PR TITLE
Remove openext function, simplify external links

### DIFF
--- a/src/popup/components/external-link.jsx
+++ b/src/popup/components/external-link.jsx
@@ -1,30 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import EnvContext from '../env-context';
-
 function ExternalLink(props) {
   const { children, href, ...other } = props;
 
   return (
-    <EnvContext.Consumer>
-      {({ openext }) => {
-        const handler = () => openext(href);
-
-        return (
-          <a
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={handler}
-            onKeyDown={handler}
-            {...other}
-          >
-            {children}
-          </a>
-        );
-      }}
-    </EnvContext.Consumer>
+    <a href={href} target="_blank" rel="noopener noreferrer" {...other}>
+      {children}
+    </a>
   );
 }
 

--- a/src/popup/components/external-link.test.jsx
+++ b/src/popup/components/external-link.test.jsx
@@ -1,61 +1,36 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import EnvContext from '../env-context';
 import ExternalLink from './external-link';
 
 describe('external-link', () => {
-  function render(overrides, env) {
+  function render(overrides) {
     const defaults = {
       children: 'link text',
       href: 'https://github.com/bitcrowd/tickety-tick',
     };
-
     const props = { ...defaults, ...overrides };
-
-    // Enzyme does not fully support the new React Context API at the moment.
-    // We work around this limitation by directly passing in the context value
-    // to the `EnvContext.Consumer` child function for rendering.
-    //
-    // See https://github.com/airbnb/enzyme/issues/1553.
-    const outer = shallow(<ExternalLink {...props} />);
-    const children = outer.find(EnvContext.Consumer).prop('children');
-    const wrapper = shallow(children(env));
-
-    return wrapper;
+    return shallow(<ExternalLink {...props} />);
   }
-
-  let openext;
-
-  beforeEach(() => {
-    openext = jest.fn();
-  });
-
-  it('calls the context openext function with the provided href on click', () => {
-    const href = 'https://bitcrowd.net/';
-    const wrapper = render({ href }, { openext });
-    wrapper.simulate('click');
-    expect(openext).toHaveBeenCalledWith(href);
-  });
 
   it('sets the link href attribute', () => {
     const href = 'https://github.com/';
-    const wrapper = render({ href }, { openext });
+    const wrapper = render({ href });
     expect(wrapper.find('a').prop('href')).toBe(href);
   });
 
   it('sets the target to "_blank"', () => {
-    const wrapper = render({}, { openext });
+    const wrapper = render({});
     expect(wrapper.find('a').prop('target')).toBe('_blank');
   });
 
   it('renders the link children', () => {
-    const wrapper = render({ children: 'neat' }, { openext });
+    const wrapper = render({ children: 'neat' });
     expect(wrapper.find('a').prop('children')).toBe('neat');
   });
 
   it('passes on any other properties to the rendered link', () => {
-    const wrapper = render({ 'data-moar': 'yep' }, { openext });
+    const wrapper = render({ 'data-moar': 'yep' });
     expect(wrapper.find('a').prop('data-moar')).toBe('yep');
   });
 });

--- a/src/popup/env-context.jsx
+++ b/src/popup/env-context.jsx
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
 
-const EnvContext = createContext({ close: null, openext: null, pbcopy: null });
+const EnvContext = createContext({ close: null, pbcopy: null });
 
 export default EnvContext;

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -21,17 +21,13 @@ function close() {
   window.close();
 }
 
-function openext() {
-  return true;
-}
-
 async function load() {
   const { tickets, errors } = await background.getTickets();
   const { options = {}, templates } = await store.get(null);
 
   const enhancer = enhance(templates, options.autofmt);
 
-  render(tickets.map(enhancer), errors, { close, openext, pbcopy });
+  render(tickets.map(enhancer), errors, { close, pbcopy });
 }
 
 window.onload = load;


### PR DESCRIPTION
Based on top of #239 (rebase + change base branch to `master` after merging that one).

The `openext` function passed down through the React element hierarchy was originally introduced to fix an issue with opening external links from the popup in Safari. With Tickety-Tick dropping support for Safari it is no longer needed.

See `src/safari-extension/popup/popup.jsx` in commit ed881e4.