### PR TITLE
Remove now unused summary format

### DIFF
--- a/src/core/enhance.js
+++ b/src/core/enhance.js
@@ -5,7 +5,6 @@ export default (templates, autofmt) => {
 
   const enhance = (ticket) => ({
     fmt: {
-      summary: fmt.summary(ticket),
       branch: fmt.branch(ticket),
       commit: fmt.commit(ticket),
       command: fmt.command(ticket),

--- a/src/core/enhance.test.js
+++ b/src/core/enhance.test.js
@@ -16,7 +16,6 @@ describe('ticket enhancer', () => {
 
     expect(enhancer(ticket)).toEqual({
       fmt: {
-        summary: formatter.summary(ticket),
         branch: formatter.branch(ticket),
         commit: formatter.commit(ticket),
         command: formatter.command(ticket),

--- a/src/core/format/defaults.js
+++ b/src/core/format/defaults.js
@@ -1,5 +1,3 @@
-export const summary = '[#{id}] {title}';
-
 export const branch = '{type | slugify}/{id | slugify}-{title | slugify}';
 
 export const commit = '[#{id}] {title}\n\n{description}\n\n{url}';

--- a/src/core/format/index.js
+++ b/src/core/format/index.js
@@ -16,7 +16,6 @@ const renderer = (templates, name) => {
 };
 
 export default (templates = {}, prettify = true) => {
-  const summary = renderer(templates, 'summary');
   const branch = renderer(templates, 'branch');
 
   // eslint-disable-next-line no-underscore-dangle
@@ -34,10 +33,5 @@ export default (templates = {}, prettify = true) => {
       ...values,
     });
 
-  return {
-    summary,
-    branch,
-    command,
-    commit,
-  };
+  return { branch, command, commit };
 };

--- a/src/options/components/form.jsx
+++ b/src/options/components/form.jsx
@@ -1,7 +1,6 @@
 import Octicon, {
   Comment,
   GitBranch,
-  Inbox,
   Terminal,
 } from '@githubprimer/octicons-react';
 import PropTypes from 'prop-types';
@@ -38,7 +37,6 @@ class Form extends Component {
     this.state = {
       loading: true,
       autofmt: true,
-      summary: '',
       branch: '',
       commit: '',
       command: '',
@@ -77,15 +75,10 @@ class Form extends Component {
 
     const { store } = this.props;
 
-    const { autofmt, summary, branch, commit, command } = this.state;
+    const { autofmt, branch, commit, command } = this.state;
 
     const options = { autofmt };
-    const templates = {
-      summary,
-      branch,
-      commit,
-      command,
-    };
+    const templates = { branch, commit, command };
 
     this.setState({ loading: true }, () => {
       store.set({ templates, options }).then(this.handleSaved);
@@ -129,15 +122,6 @@ class Form extends Component {
         value: templates.command,
         fallback: defaults.command,
         preview: fmt.command(example),
-      },
-      {
-        icon: <InputIcon icon={Inbox} />,
-        label: 'Summary Format',
-        id: 'summary-format',
-        name: 'summary',
-        value: templates.summary,
-        fallback: defaults.summary,
-        preview: fmt.summary(example),
       },
     ];
 

--- a/src/options/components/form.test.jsx
+++ b/src/options/components/form.test.jsx
@@ -49,7 +49,6 @@ describe('form', () => {
 
   beforeEach(() => {
     format.mockImplementation((templates, autofmt) => ({
-      summary: () => `formatted-summary (${autofmt})`,
       commit: () => `formatted-commit (${autofmt})`,
       branch: () => `formatted-branch (${autofmt})`,
       command: () => `formatted-command (${autofmt})`,
@@ -216,7 +215,6 @@ describe('form', () => {
 
     const unchanged = {
       templates: {
-        summary: 'summary',
         branch: 'branch',
         commit: 'commit',
         command: 'command',
@@ -239,7 +237,6 @@ describe('form', () => {
     const wrapper = render({ store });
 
     toggle(wrapper, 'autofmt', false);
-    change(wrapper, 'summary', 'summary++');
     change(wrapper, 'branch', 'branch++');
     change(wrapper, 'commit', 'commit++');
     change(wrapper, 'command', 'command++');
@@ -251,7 +248,6 @@ describe('form', () => {
 
     const changed = {
       templates: {
-        summary: 'summary++',
         branch: 'branch++',
         commit: 'commit++',
         command: 'command++',


### PR DESCRIPTION
With the more focused extension design in v4, we no longer have the "Summary" feature. This removes the format + options page code for it.

Based on #239. (If we decide not to merge 239 or to postpone it, we should "backport" these changes onto `master` befoer releasing `v4.0.0`).