### PR TITLE
[#256] Update the list of permissions

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,7 +25,6 @@
   "web_accessible_resources": [
   ],
   "permissions": [
-    "clipboardRead",
     "clipboardWrite",
     "tabs",
     "storage"


### PR DESCRIPTION
Closes #256.

Removing the `clipboardRead` permission seems to not cause any problems.

![preview](https://user-images.githubusercontent.com/706519/89116537-a5c2cc80-d484-11ea-8e59-5e3f806723fa.gif)
