### PR TITLE
[#270] GitLab integration is broken

### DIFF
--- a/src/core/adapters/gitlab.js
+++ b/src/core/adapters/gitlab.js
@@ -7,19 +7,21 @@
 import { $has, $text } from './helpers';
 
 function findTicketId(doc) {
-  const initialDataEl = doc.getElementById('js-issuable-app-initial-data');
+  const ticketId = doc.body.dataset.pageTypeId;
 
-  if (initialDataEl !== null) {
-    // Legacy approach of extracting the ticket id, left in place to support
-    // older self-hosted GitLab installations
-    const initialData = JSON.parse(
-      initialDataEl.innerHTML.replace(/&quot;/g, '"')
-    );
-
-    return initialData.issuableRef.match(/#(\d+)/)[1];
+  if (ticketId) {
+    return ticketId;
   }
 
-  return doc.body.dataset.pageTypeId;
+  const initialDataEl = doc.getElementById('js-issuable-app-initial-data');
+
+  // Legacy approach of extracting the ticket id, left in place to support
+  // older self-hosted GitLab installations
+  const initialData = JSON.parse(
+    initialDataEl.innerHTML.replace(/&quot;/g, '"')
+  );
+
+  return initialData.issuableRef.match(/#(\d+)/)[1];
 }
 
 async function scan(loc, doc) {

--- a/src/core/adapters/gitlab.js
+++ b/src/core/adapters/gitlab.js
@@ -6,14 +6,25 @@
 
 import { $has, $text } from './helpers';
 
-async function scan(loc, doc) {
-  if (doc.body.dataset.page === 'projects:issues:show') {
-    const initialDataEl = doc.getElementById('js-issuable-app-initial-data');
+function findTicketId(doc) {
+  const initialDataEl = doc.getElementById('js-issuable-app-initial-data');
+
+  if (initialDataEl !== null) {
+    // Legacy approach of extracting the ticket id, left in place to support
+    // older self-hosted GitLab installations
     const initialData = JSON.parse(
       initialDataEl.innerHTML.replace(/&quot;/g, '"')
     );
 
-    const id = initialData.issuableRef.match(/#(\d+)/)[1];
+    return initialData.issuableRef.match(/#(\d+)/)[1];
+  }
+
+  return doc.body.dataset.pageTypeId;
+}
+
+async function scan(loc, doc) {
+  if (doc.body.dataset.page === 'projects:issues:show') {
+    const id = findTicketId(doc);
     const title = $text('.issue-details .title', doc);
     const type = $has('.labels [data-original-title="bug"]', doc)
       ? 'bug'

--- a/src/core/adapters/gitlab.js
+++ b/src/core/adapters/gitlab.js
@@ -13,10 +13,9 @@ function findTicketId(doc) {
     return ticketId;
   }
 
-  const initialDataEl = doc.getElementById('js-issuable-app-initial-data');
-
   // Legacy approach of extracting the ticket id, left in place to support
   // older self-hosted GitLab installations
+  const initialDataEl = doc.getElementById('js-issuable-app-initial-data');
   const initialData = JSON.parse(
     initialDataEl.innerHTML.replace(/&quot;/g, '"')
   );

--- a/src/core/adapters/gitlab.test.js
+++ b/src/core/adapters/gitlab.test.js
@@ -3,6 +3,18 @@ import { JSDOM } from 'jsdom';
 import scan from './gitlab';
 
 const ISSUEPAGE = `
+  <body data-page-type-id="22578">
+    <div class="content">
+      <div class="issue-details">
+        <div class="detail-page-description">
+          <h2 class="title">A Random GitLab Issue</h2>
+        </div>
+      </div>
+    </div>
+  </body>
+`;
+
+const LEGACYISSUE = `
   <div class="content">
     <div class="issue-details">
       <script id="js-issuable-app-initial-data" type="application/json">
@@ -53,6 +65,13 @@ describe('gitlab adapter', () => {
 
   it('extracts tickets from issue pages', async () => {
     const result = await scan(null, dom(ISSUEPAGE, 'projects:issues:show'));
+    expect(result).toEqual([
+      { id: '22578', title: 'A Random GitLab Issue', type: 'feature' },
+    ]);
+  });
+
+  it('extracts tickets from legacy issue pages', async () => {
+    const result = await scan(null, dom(LEGACYISSUE, 'projects:issues:show'));
     expect(result).toEqual([
       { id: '22578', title: 'A Random GitLab Issue', type: 'feature' },
     ]);


### PR DESCRIPTION
Implements a new approach to extract the ticket id from a GitLab issue page. The previously used id `js-issuable-app-initial-data` is no longer present in the source. However the legacy approach is left in place to support older self-hosted GitLab installations.

I tested the development build with Chrome on the GitLab page to confirm it's working.

Closes #270 