### PR TITLE
Add link to open extension settings to popup

### DIFF
--- a/src/popup/components/__snapshots__/about.test.jsx.snap
+++ b/src/popup/components/__snapshots__/about.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`about renders 1`] = `
         className="nav-item"
       >
         <Link
-          className="nav-link"
+          className="nav-link pl-0"
           to="/"
         >
           <ChevronLeftIcon

--- a/src/popup/components/about.jsx
+++ b/src/popup/components/about.jsx
@@ -16,7 +16,7 @@ function About() {
       <Navbar>
         <ul className="navbar-nav">
           <li className="nav-item">
-            <Link className="nav-link" to="/">
+            <Link className="nav-link pl-0" to="/">
               <ChevronLeftIcon size={14} className="octicon-nav" />
               Back
             </Link>

--- a/src/popup/components/navbar.jsx
+++ b/src/popup/components/navbar.jsx
@@ -2,7 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 function Navbar({ children }) {
-  return <div className="navbar navbar-light border-bottom">{children}</div>;
+  return (
+    <div className="navbar navbar-expand navbar-light border-bottom">
+      {children}
+    </div>
+  );
 }
 
 Navbar.propTypes = {

--- a/src/popup/components/tool.jsx
+++ b/src/popup/components/tool.jsx
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 
+import EnvContext from '../env-context';
 import ErrorShape from '../utils/error-shape';
 import TicketShape from '../utils/ticket-shape';
 import Content from './content';
@@ -10,13 +11,27 @@ import NoTickets from './no-tickets';
 import TicketControls from './ticket-controls';
 
 function Tool({ tickets, errors }) {
+  const { close, openopts } = useContext(EnvContext);
+
+  async function onClickSettingsLink(event) {
+    event.preventDefault();
+    await openopts();
+    close();
+  }
+
   return (
     <>
       <Navbar>
         <span className="navbar-brand">Tickety-Tick</span>
         <ul className="navbar-nav ml-auto">
           <li className="nav-item">
-            <Link className="nav-link" to="/about">
+            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+            <a className="nav-link" href="#" onClick={onClickSettingsLink}>
+              Settings
+            </a>
+          </li>
+          <li className="nav-item">
+            <Link className="nav-link pr-0" to="/about">
               Help
             </Link>
           </li>

--- a/src/popup/components/tool.jsx
+++ b/src/popup/components/tool.jsx
@@ -25,8 +25,11 @@ function Tool({ tickets, errors }) {
         <span className="navbar-brand">Tickety-Tick</span>
         <ul className="navbar-nav ml-auto">
           <li className="nav-item">
-            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-            <a className="nav-link" href="#" onClick={onClickSettingsLink}>
+            <a
+              className="nav-link"
+              href="options.html"
+              onClick={onClickSettingsLink}
+            >
               Settings
             </a>
           </li>

--- a/src/popup/components/tool.test.jsx
+++ b/src/popup/components/tool.test.jsx
@@ -1,10 +1,17 @@
 import { shallow } from 'enzyme';
-import React from 'react';
+import React, { useContext } from 'react';
+import { Link } from 'react-router-dom';
 
 import { ticket as make } from '../../../test/factories';
+import EnvContext from '../env-context';
 import NoTickets from './no-tickets';
 import TicketControls from './ticket-controls';
 import Tool from './tool';
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn(),
+}));
 
 describe('tool', () => {
   const tickets = ['un', 'deux', 'trois'].map((title, i) =>
@@ -13,6 +20,44 @@ describe('tool', () => {
   const errors = [new Error('ouch')];
 
   let wrapper;
+
+  beforeEach(() => {
+    useContext.mockReset();
+    useContext.mockReturnValue({});
+  });
+
+  describe('always', () => {
+    const openopts = jest.fn();
+    const close = jest.fn();
+
+    beforeEach(() => {
+      useContext.mockReturnValue({ close, openopts });
+      wrapper = shallow(<Tool tickets={[]} errors={[]} />);
+      openopts.mockReset().mockResolvedValue();
+      close.mockReset();
+    });
+
+    it('renders a settings link', async () => {
+      const link = wrapper.find('a').filter({ children: 'Settings' });
+      expect(useContext).toHaveBeenCalledWith(EnvContext);
+      expect(link.exists()).toBe(true);
+
+      const preventDefault = jest.fn();
+      link.simulate('click', { preventDefault });
+
+      expect(preventDefault).toHaveBeenCalled();
+      expect(openopts).toHaveBeenCalled();
+
+      await openopts(); // wait for promise to settle
+
+      expect(close).toHaveBeenCalled();
+    });
+
+    it('renders a help link', () => {
+      const link = wrapper.find(Link).filter({ children: 'Help' });
+      expect(link.prop('to')).toBe('/about');
+    });
+  });
 
   describe('with an array of tickets', () => {
     beforeEach(() => {

--- a/src/popup/env-context.jsx
+++ b/src/popup/env-context.jsx
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
 
-const EnvContext = createContext({ close: null, pbcopy: null });
+const EnvContext = createContext({ close: null, openopts: null, pbcopy: null });
 
 export default EnvContext;

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -13,6 +13,10 @@ function close() {
   window.close();
 }
 
+function openopts() {
+  return browser.runtime.openOptionsPage();
+}
+
 async function load() {
   const background = browser.extension.getBackgroundPage();
   const { tickets, errors } = await background.getTickets();
@@ -20,7 +24,7 @@ async function load() {
 
   const enhancer = enhance(templates, options.autofmt);
 
-  render(tickets.map(enhancer), errors, { close, pbcopy });
+  render(tickets.map(enhancer), errors, { close, openopts, pbcopy });
 }
 
 window.onload = load;

--- a/src/popup/index.test.js
+++ b/src/popup/index.test.js
@@ -106,6 +106,7 @@ describe('popup', () => {
       expect.any(Object),
       {
         close: expect.any(Function),
+        openopts: expect.any(Function),
         pbcopy: expect.any(Function),
       }
     );

--- a/src/popup/styles/settings/_common.scss
+++ b/src/popup/styles/settings/_common.scss
@@ -10,3 +10,4 @@ $primary: #c32f34;
 
 $navbar-brand-font-size: $font-size-base;
 $nav-link-padding-y: 0;
+$navbar-nav-link-padding-x: 0.25rem;


### PR DESCRIPTION
During a pair-programming session with @nickgnd, I noticed that it takes a little too long to navigate to the extension settings when you just want to quickly make some adjustments.

This adds a link to the popup to open the options page. ✌️ 

![preview](https://user-images.githubusercontent.com/706519/101418840-9f3ada80-38e6-11eb-849b-b058bfca4fe1.gif)
