### PR TITLE
[#269] Switch to activeTab permission

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,8 +25,8 @@
   "web_accessible_resources": [
   ],
   "permissions": [
+    "activeTab",
     "clipboardWrite",
-    "tabs",
     "storage"
   ],
   "browser_action": {


### PR DESCRIPTION
Tested on Chrome 88 and FF 82. Ticket is recognized both when clicking
the extension icon and when pressing Ctrl+T.

Unfortunately wasn't able to find reliable information as to when support
for `activeTab` was added to the respective browsers, but at least all
current versions support it.

* https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission
* https://developer.chrome.com/docs/extensions/mv2/manifest/activeTab/
* https://dev.opera.com/extensions/declare-permissions/
* https://developer.apple.com/documentation/safariservices/safari_web_extensions/managing_safari_web_extension_permissions

Further restricting the permissions to hosts (e.g. `github.com`) would
make sense for cloud services, but could be difficult for self-hosted
providers like GitLab, so I did not pursue this further.

Closes #269.