### PR TITLE
Update "advanced configuration" README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,13 +223,9 @@ This approach works nicely with our Git workflow, for which the above assumption
 
 If you have different conventions regarding commit messages, branch names or you're just using a different source code management tool, Tickety-Tick allows you to customize the output format for all of these.
 
-In **Firefox**, open [about:addons](//about:addons) and select the Tickety-Tick preferences and scroll to the bottom of the page.
+You can access the preferences page via the "Settings" link in the Tickety-Tick popup.
 
 ![Firefox preferences](./screenshots/firefox-preferences.png)
-
-In **Chrome**, open [chrome://extensions/](//chrome://extensions), click the "Details" button on the Tickety-Tick tile and select "Extension options".
-
-In **Opera**, open [opera://extensions/](//opera://extensions), click the "Options" button on the Tickety-Tick tile.
 
 ### Auto-formatting of commit messages
 


### PR DESCRIPTION
Scrolling through the README I noticed https://github.com/bitcrowd/tickety-tick/commit/10b64df286d8a1e54bf77eaf5876f8ef2d0fd2ea introduced a "Settings" link to Tickety-Tick's popup which can be used to more easily navigate to the preferences page. This updates the "advanced configuration" README section to describe this quicker way of getting there.