### PR TITLE
Remove env context

### DIFF
--- a/src/popup/components/copy-button.jsx
+++ b/src/popup/components/copy-button.jsx
@@ -1,13 +1,6 @@
+import pbcopy from 'copy-text-to-clipboard';
 import PropTypes from 'prop-types';
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
-
-import EnvContext from '../env-context';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 function useDelayed(fn, ms) {
   const timeout = useRef(null);
@@ -32,8 +25,11 @@ function useDelayed(fn, ms) {
   return run;
 }
 
+function close() {
+  window.close();
+}
+
 function CopyButton({ children, value, ...rest }) {
-  const { close, pbcopy } = useContext(EnvContext);
   const [copied, setCopied] = useState(false);
   const closeWithDelay = useDelayed(close, 600);
 
@@ -41,7 +37,7 @@ function CopyButton({ children, value, ...rest }) {
     pbcopy(value);
     setCopied(true);
     closeWithDelay();
-  }, [closeWithDelay, pbcopy, value]);
+  }, [closeWithDelay, value]);
 
   return (
     <button type="button" {...rest} onClick={handler}>

--- a/src/popup/components/copy-button.test.jsx
+++ b/src/popup/components/copy-button.test.jsx
@@ -1,50 +1,39 @@
+import pbcopy from 'copy-text-to-clipboard';
 import { shallow } from 'enzyme';
-import React, { useContext } from 'react';
+import React from 'react';
 
-import EnvContext from '../env-context';
 import CopyButton from './copy-button';
 
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useContext: jest.fn(),
-}));
+jest.mock('copy-text-to-clipboard');
 jest.useFakeTimers();
 
 describe('copy-button', () => {
-  function render(overrides, env) {
-    useContext.mockReturnValue(env);
+  function render(overrides) {
     const defaults = { value: 'copy text' };
     const props = { ...defaults, ...overrides };
     return shallow(<CopyButton {...props} />);
   }
 
-  let pbcopy;
   let close;
 
   beforeEach(() => {
-    useContext.mockReset();
-    pbcopy = jest.fn();
-    close = jest.fn();
+    close = jest.spyOn(window, 'close').mockReturnValue(true);
   });
 
   afterEach(() => {
     jest.clearAllTimers();
-  });
-
-  it('uses the env context', () => {
-    render({}, { pbcopy }); // render to check use of context
-    expect(useContext).toHaveBeenCalledWith(EnvContext);
+    close.mockRestore();
   });
 
   it('renders its children', () => {
     const children = 'button content';
-    const wrapper = render({ children }, { pbcopy });
+    const wrapper = render({ children });
     expect(wrapper.contains(children)).toBe(true);
   });
 
   it('passes the "copied" state to its children if they are a function', () => {
     const children = jest.fn();
-    const wrapper = render({ children }, { pbcopy });
+    const wrapper = render({ children });
     expect(children).toHaveBeenNthCalledWith(1, false);
 
     wrapper.simulate('click');
@@ -54,14 +43,14 @@ describe('copy-button', () => {
 
   it('calls the context pbcopy function with the provided value on click', () => {
     const value = 'a lot of value for such a small button';
-    const wrapper = render({ value }, { pbcopy });
+    const wrapper = render({ value });
     wrapper.simulate('click');
     expect(pbcopy).toHaveBeenCalledWith(value);
   });
 
   it('calls the context close function delayed after the value was copied', () => {
     const value = 'a lot of value for such a small button';
-    const wrapper = render({ value }, { pbcopy, close });
+    const wrapper = render({ value });
     wrapper.simulate('click');
     expect(pbcopy).toHaveBeenCalledWith(value);
     expect(close).not.toHaveBeenCalled();
@@ -71,10 +60,7 @@ describe('copy-button', () => {
   });
 
   it('passes on any other properties to the rendered button', () => {
-    const wrapper = render(
-      { value: '0x2a', 'data-weirdo': 'yes, please' },
-      { pbcopy }
-    );
+    const wrapper = render({ value: '0x2a', 'data-weirdo': 'yes, please' });
     expect(wrapper.find('button').prop('data-weirdo')).toBe('yes, please');
   });
 });

--- a/src/popup/components/tool.jsx
+++ b/src/popup/components/tool.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
-import React, { useContext } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
+import browser from 'webextension-polyfill';
 
-import EnvContext from '../env-context';
 import ErrorShape from '../utils/error-shape';
 import TicketShape from '../utils/ticket-shape';
 import Content from './content';
@@ -10,9 +10,15 @@ import Navbar from './navbar';
 import NoTickets from './no-tickets';
 import TicketControls from './ticket-controls';
 
-function Tool({ tickets, errors }) {
-  const { close, openopts } = useContext(EnvContext);
+function close() {
+  window.close();
+}
 
+function openopts() {
+  return browser.runtime.openOptionsPage();
+}
+
+function Tool({ tickets, errors }) {
   async function onClickSettingsLink(event) {
     event.preventDefault();
     await openopts();

--- a/src/popup/components/tool.jsx
+++ b/src/popup/components/tool.jsx
@@ -14,14 +14,14 @@ function close() {
   window.close();
 }
 
-function openopts() {
+function openOptions() {
   return browser.runtime.openOptionsPage();
 }
 
 function Tool({ tickets, errors }) {
   async function onClickSettingsLink(event) {
     event.preventDefault();
-    await openopts();
+    await openOptions();
     close();
   }
 

--- a/src/popup/components/tool.test.jsx
+++ b/src/popup/components/tool.test.jsx
@@ -21,23 +21,24 @@ describe('tool', () => {
   const errors = [new Error('ouch')];
 
   let wrapper;
-  let openopts;
+
+  let openOptions;
   let close;
 
   beforeEach(() => {
-    openopts = browser.runtime.openOptionsPage.mockResolvedValue();
+    openOptions = browser.runtime.openOptionsPage.mockResolvedValue();
     close = jest.spyOn(window, 'close');
   });
 
   afterEach(() => {
-    openopts.mockReset();
+    openOptions.mockReset();
     close.mockRestore();
   });
 
   describe('always', () => {
     beforeEach(() => {
       wrapper = shallow(<Tool tickets={[]} errors={[]} />);
-      openopts.mockReset().mockResolvedValue();
+      openOptions.mockReset().mockResolvedValue();
       close.mockReset();
     });
 
@@ -49,9 +50,9 @@ describe('tool', () => {
       link.simulate('click', { preventDefault });
 
       expect(preventDefault).toHaveBeenCalled();
-      expect(openopts).toHaveBeenCalled();
+      expect(openOptions).toHaveBeenCalled();
 
-      await openopts(); // wait for promise to settle
+      await openOptions(); // wait for promise to settle
 
       expect(close).toHaveBeenCalled();
     });

--- a/src/popup/env-context.jsx
+++ b/src/popup/env-context.jsx
@@ -1,5 +1,0 @@
-import { createContext } from 'react';
-
-const EnvContext = createContext({ close: null, openopts: null, pbcopy: null });
-
-export default EnvContext;

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -1,21 +1,12 @@
 import './index.scss';
 import './index-dark.scss';
 
-import pbcopy from 'copy-text-to-clipboard';
 import browser from 'webextension-polyfill';
 
 import enhance from '../core/enhance';
 import store from '../store';
 import onmedia from './observe-media';
 import render from './render';
-
-function close() {
-  window.close();
-}
-
-function openopts() {
-  return browser.runtime.openOptionsPage();
-}
 
 async function load() {
   const background = browser.extension.getBackgroundPage();
@@ -24,7 +15,7 @@ async function load() {
 
   const enhancer = enhance(templates, options.autofmt);
 
-  render(tickets.map(enhancer), errors, { close, openopts, pbcopy });
+  render(tickets.map(enhancer), errors);
 }
 
 window.onload = load;

--- a/src/popup/index.test.js
+++ b/src/popup/index.test.js
@@ -80,7 +80,6 @@ describe('popup', () => {
 
     expect(render).toHaveBeenCalledWith(
       tickets.map(format),
-      expect.any(Object),
       expect.any(Object)
     );
   });
@@ -91,24 +90,6 @@ describe('popup', () => {
 
     await initialize();
 
-    expect(render).toHaveBeenCalledWith(
-      expect.any(Object),
-      errors,
-      expect.any(Object)
-    );
-  });
-
-  it('renders the popup content with context', async () => {
-    await initialize();
-
-    expect(render).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.any(Object),
-      {
-        close: expect.any(Function),
-        openopts: expect.any(Function),
-        pbcopy: expect.any(Function),
-      }
-    );
+    expect(render).toHaveBeenCalledWith(expect.any(Object), errors);
   });
 });

--- a/src/popup/render.jsx
+++ b/src/popup/render.jsx
@@ -4,7 +4,6 @@ import { MemoryRouter as Router, Route } from 'react-router';
 
 import About from './components/about';
 import Tool from './components/tool';
-import EnvContext from './env-context';
 
 function propped(Component, defaults) {
   const ProppedComponent = (more) => {
@@ -15,16 +14,14 @@ function propped(Component, defaults) {
   return ProppedComponent;
 }
 
-function render(tickets, errors, env) {
+function render(tickets, errors) {
   const root = document.getElementById('popup-root');
 
   const element = (
-    <EnvContext.Provider value={env}>
-      <Router>
-        <Route exact path="/" component={propped(Tool, { tickets, errors })} />
-        <Route path="/about" component={About} />
-      </Router>
-    </EnvContext.Provider>
+    <Router>
+      <Route exact path="/" component={propped(Tool, { tickets, errors })} />
+      <Route path="/about" component={About} />
+    </Router>
   );
 
   ReactDOM.render(element, root);


### PR DESCRIPTION
We no longer have different entry points for Safari and other browsers.
We can drop the formerly browser-specific `EnvContext` and simplify the
setup.
