### PR TITLE
Try formatter package with build output removed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,13 +28,13 @@ commands:
     description: Restore dependencies
     steps:
       - restore_cache:
-          key: dependency-cache-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: dependency-cache-v2-{{ arch }}-{{ checksum "yarn.lock" }}
 
   save_deps:
     description: Save dependencies
     steps:
       - save_cache:
-          key: dependency-cache-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: dependency-cache-v2-{{ arch }}-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
 

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-svg": "^13.0.2",
     "react-textarea-autosize": "^8.3.2",
     "stacktrace-js": "^2.0.0",
-    "tickety-tick-formatter": "bitcrowd/tickety-tick-formatter",
+    "tickety-tick-formatter": "bitcrowd/tickety-tick-formatter#feature/7-remove-dist-from-repo",
     "webextension-polyfill": "^0.8.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10319,9 +10319,9 @@ through@2:
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-tickety-tick-formatter@bitcrowd/tickety-tick-formatter:
+tickety-tick-formatter@bitcrowd/tickety-tick-formatter#feature/7-remove-dist-from-repo:
   version "1.0.0"
-  resolved "https://codeload.github.com/bitcrowd/tickety-tick-formatter/tar.gz/01919012d8f399c4bf543ebed7745ef7410c435e"
+  resolved "https://codeload.github.com/bitcrowd/tickety-tick-formatter/tar.gz/8e9358f1d51351003486993b035f84cfdea03ba3"
   dependencies:
     prettier "^2.2.1"
     speakingurl "^14.0.1"


### PR DESCRIPTION
Try using the formatter package from GitHub without included build:
https://github.com/bitcrowd/tickety-tick-formatter/pull/8

This PR is just here to try and see whether this works.
We can scrap this PR (or update it to reference the default formatter branch again).

I had to `rm -rf node_modules` before running `npm install` or `yarn install` again for the package to be built.