### PR TITLE
Explcitly set the language for the exported cert to en

### DIFF
--- a/script/extract-cert-ou
+++ b/script/extract-cert-ou
@@ -12,7 +12,7 @@ fi
 certname="$1"
 
 exec security find-certificate -a -c "$certname" -p \
-  | keytool -printcert \
+  | keytool -printcert -J-Duser.language=en \
   | grep 'Owner: ' \
   | head -n 1 \
   | sed -n -e 's/^.*OU=\([^:space:,]*\).*$/\1/p'


### PR DESCRIPTION
When using the script `script/extract-cert-ou` with another locale than en (e.g., de), the owner of the certificate can not be found ("Aussteller" vs. "Owner").