### PR TITLE
Add Linear.app adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Currently, we support:
 - [Notion](https://www.notion.so/)
 - [Tara](https://app.tara.ai/)
 - [Trello](https://trello.com/)
+- [Linear](https://linear.app)
 
 Your ticket system is missing? Go ahead and implement an adapter for it! We are always happy about contributions and here to support you 👋.
 

--- a/src/core/adapters/linear.test.ts
+++ b/src/core/adapters/linear.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment node
+ */
+
+import { JSDOM } from "jsdom";
+
+import scan from "./linear";
+
+const pages = {
+  issuePage: {
+    url: new URL(
+      "https://linear.app/my_team/issue/FOO-1/do-something-interesting"
+    ),
+    document: "<span title='Edit issue title'>Do something interesting</span>",
+  },
+};
+
+describe("linear adapter", () => {
+  function doc(body = "") {
+    const { window } = new JSDOM(`<html><body>${body}</body></html>`);
+    return window.document;
+  }
+
+  it("returns an empty array if it is on a different page", async () => {
+    const result = await scan(new URL("https://example.com"), doc());
+    expect(result).toEqual([]);
+  });
+
+  it("extracts the ticket from the issue page", async () => {
+    const result = await scan(
+      pages.issuePage.url,
+      doc(pages.issuePage.document)
+    );
+    expect(result).toEqual([
+      {
+        id: "FOO-1",
+        title: "Do something interesting",
+        type: "issue",
+        url: pages.issuePage.url.toString(),
+      },
+    ]);
+  });
+});

--- a/src/core/adapters/linear.ts
+++ b/src/core/adapters/linear.ts
@@ -1,0 +1,34 @@
+/**
+ * Linear adapter
+ *
+ * The adapter extracts ticket information from the markup. Note that linear
+ * obfuscates classes, so the DOM selectors are probably not reliable (for one,
+ * they are locale dependent, but at this time Linear is only available in
+ * English).
+ *
+ */
+
+import { match } from "micro-match";
+
+import type { TicketData } from "../types";
+import { $text } from "./dom-helpers";
+
+async function scan(url: URL, document: Document): Promise<TicketData[]> {
+  if (url.hostname !== "linear.app") return [];
+
+  const { id, issueType } = match("/:team/:issueType/:id/:slug", url.pathname);
+  const title = $text('[title="Edit issue title"]', document);
+
+  if (!id) return [];
+
+  const ticket = {
+    id,
+    url: url.toString(),
+    title,
+    type: issueType,
+  } as TicketData;
+
+  return [ticket];
+}
+
+export default scan;

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -4,6 +4,7 @@ import type { Ticket } from "../types";
 import GitHub from "./adapters/github";
 import GitLab from "./adapters/gitlab";
 import Jira from "./adapters/jira";
+import Linear from "./adapters/linear";
 import Notion from "./adapters/notion";
 import Tara from "./adapters/tara";
 import Trello from "./adapters/trello";
@@ -36,7 +37,15 @@ async function search(adapters: Adapter[], url: URL, document: Document) {
   return aggregate(results);
 }
 
-const stdadapters: Adapter[] = [GitHub, GitLab, Jira, Notion, Tara, Trello];
+const stdadapters: Adapter[] = [
+  GitHub,
+  GitLab,
+  Jira,
+  Notion,
+  Tara,
+  Trello,
+  Linear,
+];
 
 export { search, stdadapters };
 export default search.bind(null, stdadapters);

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -41,10 +41,10 @@ const stdadapters: Adapter[] = [
   GitHub,
   GitLab,
   Jira,
+  Linear,
   Notion,
   Tara,
   Trello,
-  Linear,
 ];
 
 export { search, stdadapters };

--- a/src/popup/components/__snapshots__/no-tickets.test.tsx.snap
+++ b/src/popup/components/__snapshots__/no-tickets.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`no-tickets with no errors renders a hint 1`] = `
     <p>
       Tickety-Tick currently supports
       <br />
-      GitHub, GitLab, Jira, Trello, Notion and Tara.
+      GitHub, GitLab, Jira, Trello, Notion, Tara and Linear.
     </p>
     <h6>
       Missing anything or found a bug?

--- a/src/popup/components/no-tickets.tsx
+++ b/src/popup/components/no-tickets.tsx
@@ -19,7 +19,7 @@ function Hint() {
       <p>
         Tickety-Tick currently supports
         <br />
-        GitHub, GitLab, Jira, Trello, Notion and Tara.
+        GitHub, GitLab, Jira, Trello, Notion, Tara and Linear.
       </p>
       <h6>Missing anything or found a bug?</h6>
       <p className="pb-1">


### PR DESCRIPTION
Adds a simple, DOM based [Linear](https://linear.app/) adapter.

The selectors are fragile (because Linear minimizes their CSS so we can't use their CSS classes) and will require updating if Linear adds more languages.

I had a few issues locally:
1. after running any tasks that create `dist/` the path is picked up by `yarn test` which produces a lot of confusing test failures
1. (_this is only an issue if one doesn't want to install Rosetta_) the build system uses some notifiers that come with pre-built x86 executables for `terminal-notifier`. Those will crash on arm64 (Apple M1). Since `terminal-notifier` seems unmaintained, as a (very) dirty work-around one can compile `terminal-notifier` to get an arm64 executable (for example via `brew`) and use that binary instead:
```
brew install terminal-notifier
ln -sf `which terminal-notifier` node_modules/node-notifier/node_modules/node-notifier/vendor/mac.noindex/terminal-notifier.app/Contents/MacOS/terminal-notifier
ln -sf `which terminal-notifier` node_modules/webpack-build-notifier/node_modules/node-notifier/vendor/mac.noindex/terminal-notifier.app/Contents/MacOS/terminal-notifier
```
In lieu of a better fix, maybe we should add this to the README?