### PR TITLE
[331] Chrome setting screen is growing forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ You can run both `watch:[browser]` and `open:[browser]` scripts in parallel to a
 
 #### Tips & Tricks 🎩
 
-Use the Firefox developer tools to [debug the extension](https://extensionworkshop.com/documentation/develop/debugging/).
+* Debugging
+  * Firefox: use the developer tools to [debug the extension](https://extensionworkshop.com/documentation/develop/debugging/)
+  * Chrome: right-click `inspect` on the popup or the settings page to open a separate debugger
 
 ### Running automated checks
 

--- a/src/options/components/template-input.tsx
+++ b/src/options/components/template-input.tsx
@@ -86,7 +86,7 @@ function TemplateInput(props: Props) {
       </div>
       <div className="card">
         <div className="card-body">
-          <pre className="small text-muted mw-100 m-0 overflow-auto">
+          <pre className="small text-muted mw-100ch m-0 overflow-auto">
             {preview}
           </pre>
         </div>

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -2,9 +2,10 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Options</title>
   </head>
-  <body class="vw-100">
+  <body>
     <div id="options-root"></div>
   </body>
 </html>

--- a/src/options/styles/_additions.scss
+++ b/src/options/styles/_additions.scss
@@ -8,3 +8,7 @@ body {
 .input-checkbox {
   margin: 0 2px !important;
 }
+
+.mw-100ch {
+  max-width: 100ch;
+}


### PR DESCRIPTION
Apply a character-maximum width to the preview sections of the form. This stops Chrome from making the dialog grow forever.

![settings](https://user-images.githubusercontent.com/3491815/157653146-046f44b8-f3b9-42f8-a23d-9b7165f8e969.gif)


Side-party 🎉: also add a note about debugging the options page in Chrome to the README (thanks @ArinzeJeffrey-droid)

Closes: #331
