### PR TITLE
[337] Remove terminal notification setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "typescript": "^4.4.2",
     "web-ext": "^6.8.0",
     "webpack": "5.55.1",
-    "webpack-build-notifier": "2.3.0",
     "webpack-chain": "6.5.1",
     "webpack-cli": "^4.6.0",
     "zip-webpack-plugin": "4.0.1"

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -7,7 +7,6 @@ import { GitRevisionPlugin } from "git-revision-webpack-plugin";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import { DefinePlugin } from "webpack";
-import NotifierPlugin from "webpack-build-notifier";
 import ZipWebpackPlugin from "zip-webpack-plugin";
 import Config from "webpack-chain";
 
@@ -191,14 +190,6 @@ config
       COMMITHASH: JSON.stringify(revision.commithash()),
     },
   ]);
-
-// Show build notifications.
-
-config.plugin("notifier").use(NotifierPlugin, [
-  {
-    title: "Tickety-Tick Build",
-  },
-]);
 
 // Configure source-maps.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7083,18 +7083,6 @@ node-notifier@9.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
-node-notifier@9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-9.0.1.tgz#cea837f4c5e733936c7b9005e6545cea825d1af4"
-  integrity sha512-fPNFIp2hF/Dq7qLDzSg4vZ0J4e9v60gJR+Qx7RbjbWqzPDdEqeVpEx5CFeDAELIl+A/woaaNn1fQ5nEVerMxJg==
-  dependencies:
-    growly "^1.3.0"
-    is-wsl "^2.2.0"
-    semver "^7.3.2"
-    shellwords "^0.1.1"
-    uuid "^8.3.0"
-    which "^2.0.2"
-
 node-releases@^1.1.76:
   version "1.1.76"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.76.tgz#df245b062b0cafbd5282ab6792f7dccc2d97f36e"
@@ -10400,14 +10388,6 @@ webidl-conversions@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
-
-webpack-build-notifier@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/webpack-build-notifier/-/webpack-build-notifier-2.3.0.tgz#cb314fbe85b2684e00443b465c08026e812b83f5"
-  integrity sha512-+/s6GrvSRwP0CHqHOqZcta7EcqjL1MUR9KmBSlkJj6xJVZtFB/z68CTeLPrHnMED/umlXN9hcFV8wmGjeI/K2A==
-  dependencies:
-    node-notifier "9.0.1"
-    strip-ansi "^6.0.0"
 
 webpack-chain@6.5.1:
   version "6.5.1"


### PR DESCRIPTION
[337](https://github.com/bitcrowd/tickety-tick/issues/337)

Remove the `webpack-build-notifier` package. It relies on unmaintained packages which aren't compatible with M1 Macs out of the box any more.
