### PR TITLE
Update CI base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ definitions:
 executors:
   base:
     docker:
-      - image: circleci/node:lts
+      - image: cimg/node:lts
     working_directory: *pwd
   swift:
     docker:


### PR DESCRIPTION
Use the faster next gen image for NodeJS.

See [this blog post](https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/) for a reference.

Unfortunately, for the Swift image we're using, Circle does not have their own images.
