### PR TITLE
[348] Error: unsupported node type "expand"

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "bootstrap": "5.1.1",
     "copy-text-to-clipboard": "^3.0.1",
     "ky": "^0.28.5",
-    "mdast-util-from-adf": "^2.0.0",
+    "mdast-util-from-adf": "^2.1.0",
     "mdast-util-gfm": "^2.0.0",
     "mdast-util-to-markdown": "^1.2.3",
     "micro-match": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,12 +10,13 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@atlaskit/adf-schema@^19.2.0":
-  version "19.3.1"
-  resolved "https://registry.yarnpkg.com/@atlaskit/adf-schema/-/adf-schema-19.3.1.tgz#f64486ab0d494e45af6903e1dc714b79976cf771"
-  integrity sha512-sqiPGYx/2fzN1yP3bafAj1YaUV4Wsvy/bEKNrxMW+RljvUPxNTEAHS7Q3+CSmPiwETqwpDcDhp4uozPU9PfY4g==
+"@atlaskit/adf-schema@^24.0.0":
+  version "24.0.2"
+  resolved "https://registry.yarnpkg.com/@atlaskit/adf-schema/-/adf-schema-24.0.2.tgz#42097a0683238039f5b216caa76d76410ccb18b2"
+  integrity sha512-HZSgTsAn7/+veYOK3KPwaVlmDWHEstxV4QszQ0sjeeNNmcLxu8tba0+PPPR6Cls6LWYLvGlvqoD3UJZN3JAJkw==
   dependencies:
-    "@atlaskit/editor-tables" "^2.0.0"
+    "@atlaskit/codemod-utils" "^4.1.0"
+    "@atlaskit/editor-tables" "^2.2.0"
     "@babel/runtime" "^7.0.0"
     "@types/linkify-it" "^2.0.4"
     "@types/prosemirror-model" "^1.11.0"
@@ -23,21 +24,28 @@
     css-color-names "0.0.4"
     linkify-it "^2.0.3"
     memoize-one "^6.0.0"
-    prosemirror-model "1.11.0"
-    prosemirror-transform "1.2.8"
+    prosemirror-model "1.14.3"
+    prosemirror-transform "1.3.2"
 
-"@atlaskit/editor-tables@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@atlaskit/editor-tables/-/editor-tables-2.0.1.tgz#5332ab1845f8c9fffda5a3777a862a47d755d9ff"
-  integrity sha512-HEYJmsZSpZy8BV8l6v4O9SSAfwvPqfwear7QWgrxnL7G3muqjvgIqCTAzKPpjqMzYiiZdyL8DLBM8DfHhwmWsA==
+"@atlaskit/codemod-utils@^4.1.0":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@atlaskit/codemod-utils/-/codemod-utils-4.1.3.tgz#bcc7ff725ac153684a366fc54ab1f532a531d811"
+  integrity sha512-KQ4e5DGPth2UskAsrFE3kmeVWJST2BgXABGExXnnO1LbnIPNBP/cnemVN1Pzw2JELMXyHTCeUZAoHxVcAYtD0g==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+"@atlaskit/editor-tables@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@atlaskit/editor-tables/-/editor-tables-2.2.0.tgz#85dbcd76afba18ab20be79584efadc49501392f1"
+  integrity sha512-FqPqw7CK3CmXXj0vR8jVniuSBcK/PlkeVfgeyeiv27GmaAry7EMnH4CB2kOQ1oqYWH7QXjXx5/Sehwd6+evb7g==
   dependencies:
     "@babel/runtime" "^7.0.0"
     prosemirror-keymap "1.1.4"
-    prosemirror-model "1.11.0"
-    prosemirror-state "1.3.3"
-    prosemirror-transform "1.2.8"
+    prosemirror-model "1.14.3"
+    prosemirror-state "1.3.4"
+    prosemirror-transform "1.3.2"
     prosemirror-utils "^1.0.0-0"
-    prosemirror-view "1.15.4"
+    prosemirror-view "1.23.2"
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"
@@ -3769,14 +3777,9 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001259:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001259, caniuse-lite@^1.0.30001400:
   version "1.0.30001422"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz"
-  integrity sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==
-
-caniuse-lite@^1.0.30001400:
-  version "1.0.30001422"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz#f2d7c6202c49a8359e6e35add894d88ef93edba1"
   integrity sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==
 
 caseless@~0.12.0:
@@ -7571,12 +7574,12 @@ mdast-util-find-and-replace@^2.0.0:
     unist-util-is "^5.0.0"
     unist-util-visit-parents "^4.0.0"
 
-mdast-util-from-adf@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-from-adf/-/mdast-util-from-adf-2.0.0.tgz#1554c5cac0c725e03b52baef515c66271e17d798"
-  integrity sha512-V1a5UNLvCsSwTCbfgVKOVBlVnuxXMaW2yDav0tsoqcv6zjjfRK7cdHTy9G6sttdpl1P0okOCQtsTC8COaOfMCw==
+mdast-util-from-adf@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-adf/-/mdast-util-from-adf-2.1.0.tgz#bef4bc9cdd4979e34d4033a98cf4ed6a0c0aa8fc"
+  integrity sha512-JjQrthlokpsesMiZYFuEXO+PBq2LEf9aitY5UjewmBuOz/iCAPsKRh33FplvFBsbMz2obPgETD7eHFEjVGyLvg==
   dependencies:
-    "@atlaskit/adf-schema" "^19.2.0"
+    "@atlaskit/adf-schema" "^24.0.0"
     "@types/mdast" "^3.0.0"
     unist-builder "^3.0.0"
 
@@ -8236,6 +8239,11 @@ orderedmap@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/orderedmap/-/orderedmap-1.1.1.tgz#c618e77611b3b21d0fe3edc92586265e0059c789"
   integrity sha512-3Ux8um0zXbVacKUkcytc0u3HgC0b0bBLT+I60r2J/En72cI0nZffqrA7Xtf2Hqs27j1g82llR5Mhbd0Z1XW4AQ==
+
+orderedmap@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/orderedmap/-/orderedmap-2.1.0.tgz#819457082fa3a06abd316d83a281a1ca467437cd"
+  integrity sha512-/pIFexOm6S70EPdznemIz3BQZoJ4VTFrhqzu0ACBqBgeLsLxq8e6Jim63ImIfwW/zAD1AlXpRMlOv3aghmo4dA==
 
 os-locale@5.0.0:
   version "5.0.0"
@@ -9307,29 +9315,28 @@ prosemirror-keymap@1.1.4:
     prosemirror-state "^1.0.0"
     w3c-keyname "^2.2.0"
 
-prosemirror-model@1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.11.0.tgz#dc36cdb3ad6442b9f6325c7d89170c624f9dc520"
-  integrity sha512-GqoAz/mIYjdv8gVYJ8mWFKpHoTxn/lXq4tXJ6bTVxs+rem2LzMYXrNVXfucGtfsgqsJlRIgng/ByG9j7Q8XDrg==
+prosemirror-model@1.14.3:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.14.3.tgz#a9c250d3c4023ddf10ecb41a0a7a130e9741d37e"
+  integrity sha512-yzZlBaSxfUPIIP6U5Edh5zKxJPZ5f7bwZRhiCuH3UYkWhj+P3d8swHsbuAMOu/iDatDc5J/Qs5Mb3++mZf+CvQ==
   dependencies:
     orderedmap "^1.1.0"
 
-prosemirror-model@^1.0.0, prosemirror-model@^1.1.0:
+prosemirror-model@^1.0.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.15.0.tgz#23bc09098daa7c309dba90a76a1b989ce6f61405"
   integrity sha512-hQJv7SnIhlAy9ga3lhPPgaufhvCbQB9tHwscJ9E1H1pPHmN8w5V/lURueoYv9Kc3/bpNWoyHa8r3g//m7N0ChQ==
   dependencies:
     orderedmap "^1.1.0"
 
-prosemirror-state@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/prosemirror-state/-/prosemirror-state-1.3.3.tgz#b2862866b14dec2b3ae1ab18229f2bd337651a2c"
-  integrity sha512-PLXh2VJsIgvlgSTH6I2Yg6vk1CzPDp21DFreVpQtDMY2S6WaMmrQgDTLRcsrD8X38v8Yc873H7+ogdGzyIPn+w==
+prosemirror-model@^1.14.3:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.18.1.tgz#1d5d6b6de7b983ee67a479dc607165fdef3935bd"
+  integrity sha512-IxSVBKAEMjD7s3n8cgtwMlxAXZrC7Mlag7zYsAKDndAqnDScvSmp/UdnRTV/B33lTCVU3CCm7dyAn/rVVD0mcw==
   dependencies:
-    prosemirror-model "^1.0.0"
-    prosemirror-transform "^1.0.0"
+    orderedmap "^2.0.0"
 
-prosemirror-state@^1.0.0:
+prosemirror-state@1.3.4, prosemirror-state@^1.0.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/prosemirror-state/-/prosemirror-state-1.3.4.tgz#4c6b52628216e753fc901c6d2bfd84ce109e8952"
   integrity sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==
@@ -9337,10 +9344,10 @@ prosemirror-state@^1.0.0:
     prosemirror-model "^1.0.0"
     prosemirror-transform "^1.0.0"
 
-prosemirror-transform@1.2.8:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/prosemirror-transform/-/prosemirror-transform-1.2.8.tgz#4b86544fa43637fe381549fb7b019f4fb71fe65c"
-  integrity sha512-hKqceqv9ZmMQXNQkhFjr0KFGPvkhygaWND+uIM0GxRpALrKfxP97SsgHTBs3OpJhDmh5N+mB4D/CksB291Eavg==
+prosemirror-transform@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/prosemirror-transform/-/prosemirror-transform-1.3.2.tgz#5620ebe7379e6fae4f34ecc881886cb22ce96579"
+  integrity sha512-/G6d/u9Mf6Bv3H1XR8VxhpjmUO75LYmnvj+s3ZfZpakU1hnQbsvCEybml1B3f2IWUAAQRFkbO1PnsbFhLZsYsw==
   dependencies:
     prosemirror-model "^1.0.0"
 
@@ -9356,12 +9363,12 @@ prosemirror-utils@^1.0.0-0:
   resolved "https://registry.yarnpkg.com/prosemirror-utils/-/prosemirror-utils-1.0.0-0.tgz#7dfd112abf69001508a76200f9c8660fda7fa85f"
   integrity sha512-11hTMG4Qwqlux6Vwp/4m16mLDg6IwWb0/odsWXGtWvvRJo61SfG0RGYlA8H72vExmbnWpiXa7PNenZ6t12Rkqw==
 
-prosemirror-view@1.15.4:
-  version "1.15.4"
-  resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.15.4.tgz#69a6217e3557dd1eb34a6d45caed1c3ee8e05b12"
-  integrity sha512-SzcszIrDJnQIS+f7WiS5KmQBfdYEhPqp/Hx9bKmXH7ZxrxRiBKPy1/9MoZzxjXUkm+5WHjX+N1fjAMXKoz/OQw==
+prosemirror-view@1.23.2:
+  version "1.23.2"
+  resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.23.2.tgz#20606ab3faad8a6a5320182256e92a2b96a87d31"
+  integrity sha512-iPgRw6tpcN+KH1yKmSnRmDKsJBVkWLFP6laHcz9rh/n0Ndz7YKKCDldtw6FhHBYoWmZeubbhV/rrQW0VCDG9iw==
   dependencies:
-    prosemirror-model "^1.1.0"
+    prosemirror-model "^1.14.3"
     prosemirror-state "^1.0.0"
     prosemirror-transform "^1.1.0"
 


### PR DESCRIPTION
[348](https://github.com/bitcrowd/tickety-tick/issues/348)

This updates the `mdast-util-from-adf` to [v2.1.0](https://github.com/bitcrowd/mdast-util-from-adf/releases/tag/v2.1.0) which adds support for `epand` notes in Jira.

The title of the expand section is ignored and the content just added to the normal document flow. Can you check if that fixes #348 for you @agatheblues?

Special thanks to @pmeinhardt 💚
