### PR TITLE
[#362] Expose notion page url

### DIFF
--- a/src/core/adapters/notion.test.ts
+++ b/src/core/adapters/notion.test.ts
@@ -8,7 +8,7 @@ describe("notion adapter", () => {
   const title = "Add notion.so support";
   const slugId = "5b1d7dd791074890b2ec83175b8eda83";
   const slug = `Add-notion-so-support-${slugId}`;
-  const ticketUrl = `https://www.notion.so/notionuser/${slugId}`;
+  const ticketUrl = `https://www.notion.so/${slugId}`;
 
   const response = {
     results: [

--- a/src/core/adapters/notion.test.ts
+++ b/src/core/adapters/notion.test.ts
@@ -8,6 +8,7 @@ describe("notion adapter", () => {
   const title = "Add notion.so support";
   const slugId = "5b1d7dd791074890b2ec83175b8eda83";
   const slug = `Add-notion-so-support-${slugId}`;
+  const ticketUrl = `https://www.notion.so/notionuser/${slugId}`;
 
   const response = {
     results: [
@@ -22,7 +23,7 @@ describe("notion adapter", () => {
     ],
   };
 
-  const ticket = { id, title, type: "page" };
+  const ticket = { id, title, type: "page", url: ticketUrl };
   const url = (str: string) => new URL(str);
   const api = { post: jest.fn() };
 

--- a/src/core/adapters/notion.ts
+++ b/src/core/adapters/notion.ts
@@ -73,11 +73,6 @@ function getTickets(response: NotionTicketResponse, id: string) {
     .filter((t) => t && t.id === id) as TicketData[];
 }
 
-function buildUrl(url: URL, id: string): string {
-  const { organization } = match("/:organization/:slug", url.pathname);
-  return `https://www.notion.so/${organization}/${id}`;
-}
-
 async function scan(url: URL): Promise<TicketData[]> {
   if (url.host !== "www.notion.so") return [];
 
@@ -93,7 +88,7 @@ async function scan(url: URL): Promise<TicketData[]> {
     .json<NotionTicketResponse>();
 
   return getTickets(response, id).map((ticket) => ({
-    url: buildUrl(url, slugId),
+    url: `https://www.notion.so/${slugId}`,
     ...ticket,
   })) as TicketData[];
 }


### PR DESCRIPTION
This PR adds the URL to a ticket in the Notion adapter. It will work on both the ticket show and the board view (modal). It relies on Notion redirecting from `/id` to `/slug`.

https://github.com/bitcrowd/tickety-tick/issues/362