### PR TITLE
[#369] Support notion pages without organizations

### DIFF
--- a/src/core/adapters/notion.test.ts
+++ b/src/core/adapters/notion.test.ts
@@ -113,4 +113,12 @@ describe("notion adapter", () => {
     });
     expect(result).toEqual([ticket]);
   });
+
+  it("extracts tickets from the page view without organization", async () => {
+    const result = await scan(url(`https://www.notion.so/${slug}`));
+    expect(api.post).toHaveBeenCalledWith("api/v3/getRecordValues", {
+      json: { requests: [{ table: "block", id }] },
+    });
+    expect(result).toEqual([ticket]);
+  });
 });

--- a/src/core/adapters/notion.ts
+++ b/src/core/adapters/notion.ts
@@ -9,6 +9,8 @@
  * API yet.
  */
 
+import { match } from "micro-match";
+
 import client from "../client";
 import type { TicketData } from "../types";
 
@@ -41,7 +43,7 @@ function uuid(slugId: string | null) {
 }
 
 function getPageFromPath(path: string) {
-  const slug = path.split("/").slice(-1)[0];
+  const { slug } = match(":organization?/:slug", path);
   if (!slug) return null;
 
   return slug.replace(/.*-/, ""); // strip title from slug

--- a/src/core/adapters/notion.ts
+++ b/src/core/adapters/notion.ts
@@ -30,9 +30,7 @@ type NotionTicketResponse = {
  * Turns a slugged page ID without dashes into a dasherized RFC 4122 UUID.
  * UUID-Format: 96ec637d-e4b0-4a5e-acf3-8d4d9a1b2e4b
  */
-function uuid(slugId: string | null) {
-  if (!slugId) return null;
-
+function uuid(slugId: string) {
   return [
     slugId.substring(0, 8),
     slugId.substring(8, 12),
@@ -79,10 +77,9 @@ async function scan(url: URL): Promise<TicketData[]> {
   if (url.host !== "www.notion.so") return [];
 
   const slugId = getSelectedPageId(url);
+  if (!slugId) return [];
+
   const id = uuid(slugId);
-
-  if (!id) return [];
-
   const api = client(`https://${url.host}`);
   const request = { json: { requests: [{ table: "block", id }] } };
   const response = await api

--- a/src/core/adapters/notion.ts
+++ b/src/core/adapters/notion.ts
@@ -9,8 +9,6 @@
  * API yet.
  */
 
-import { match } from "micro-match";
-
 import client from "../client";
 import type { TicketData } from "../types";
 
@@ -30,7 +28,9 @@ type NotionTicketResponse = {
  * Turns a slugged page ID without dashes into a dasherized RFC 4122 UUID.
  * UUID-Format: 96ec637d-e4b0-4a5e-acf3-8d4d9a1b2e4b
  */
-function uuid(slugId: string) {
+function uuid(slugId: string | null) {
+  if (!slugId) return null;
+
   return [
     slugId.substring(0, 8),
     slugId.substring(8, 12),
@@ -41,7 +41,7 @@ function uuid(slugId: string) {
 }
 
 function getPageFromPath(path: string) {
-  const { slug } = match("/:organization/:slug", path);
+  const slug = path.split("/").slice(-1)[0];
   if (!slug) return null;
 
   return slug.replace(/.*-/, ""); // strip title from slug


### PR DESCRIPTION
Removes dependence on :organization in ticket path
https://github.com/bitcrowd/tickety-tick/issues/369