### PR TITLE
[401] Fix GitHub adapter bug label detection

### DIFF
--- a/src/core/adapters/github.test.ts
+++ b/src/core/adapters/github.test.ts
@@ -22,29 +22,28 @@ const pages = {
           <span class="gh-header-number">#12</span>
         </h1>
         <div class="js-issue-labels">
-          <a class="sidebar-labels-style" title="bug">bug</a>
+          <a class="IssueLabel hx_IssueLabel" data-name="bug">bug</a>
         </div>
       </div>`,
     indexpage: `
         <div class="js-check-all-container">
-          <ul>
-            <li id="issue_12" class="js-issue-row selected">
+          <div>
+            <div id="issue_12" class="js-issue-row selected">
               <input type="checkbox" class="js-issues-list-check" name="issues[]" value="12">
               <a href="/bitcrowd/tickety-tick/issues/12" class="h4 js-navigation-open">
                 A Selected GitHub Issue
               </a>
-              <span class="labels">
+              <span class="lh-default">
                 <a href="#" class="IssueLabel">bug</a>
               </span>
-            </li>
-            <li id="issue_11" class="js-issue-row">
+            </div>
+            <div id="issue_11" class="js-issue-row">
               <input type="checkbox" class="js-issues-list-check" name="issues[]" value="11">
               <a href="/bitcrowd/tickety-tick/issues/11" class="h4 js-navigation-open">
                 A GitHub Issue
               </a>
-              <span class="labels"></span>
-            </li>
-          </ul>
+            </div>
+          </div>
         </div>`,
     projectpage: `
         <div class="project-columns">

--- a/src/core/adapters/github.test.ts
+++ b/src/core/adapters/github.test.ts
@@ -45,27 +45,6 @@ const pages = {
             </div>
           </div>
         </div>`,
-    projectpage: `
-        <div class="project-columns">
-          <div class="project-card"
-              data-card-state='["open"]'
-              data-card-label='["enhancement"]'
-              data-card-title='["an","example","feature","ticket","42","#42"]'>
-            <a class="h5">An Example Feature Ticket</a>
-          </div>
-          <div class="project-card"
-              data-card-state='["open"]'
-              data-card-label='["bug"]'
-              data-card-title='["an","example","bug","ticket","43","#43"]'>
-            <a class="h5">An Example Bug Ticket</a>
-          </div>
-          <div class="project-card"
-              data-card-state='["closed"]'
-              data-card-label='["bug"]'
-              data-card-title='["an","example","bug","ticket","which","was","closed","and","should","not","be","found","44","#44"]'>
-            <a class="h5">An Example Bug Ticket which was closed and should not be found</a>
-          </div>
-        </div>`,
   },
   legacy: {
     issuepage: `
@@ -108,28 +87,6 @@ const pages = {
           </li>
         </ul>
       </div>`,
-
-    projectpage: `
-      <div class="project-columns">
-        <div class="project-card"
-            data-card-state='["open"]'
-            data-card-label='["enhancement"]'
-            data-card-title='["an","example","feature","ticket","42","#42"]'>
-          <a class="h5">An Example Feature Ticket</a>
-        </div>
-        <div class="project-card"
-            data-card-state='["open"]'
-            data-card-label='["bug"]'
-            data-card-title='["an","example","bug","ticket","43","#43"]'>
-          <a class="h5">An Example Bug Ticket</a>
-        </div>
-        <div class="project-card"
-            data-card-state='["closed"]'
-            data-card-label='["bug"]'
-            data-card-title='["an","example","bug","ticket","which","was","closed","and","should","not","be","found","44","#44"]'>
-          <a class="h5">An Example Bug Ticket which was closed and should not be found</a>
-        </div>
-      </div>`,
   },
 };
 
@@ -139,7 +96,6 @@ const url = (path: string) =>
 Object.keys(selectors).forEach((variant) => {
   const html = pages[variant as keyof typeof selectors];
 
-  // eslint-disable-next-line jest/valid-describe
   describe(`github adapter (${variant})`, () => {
     function doc(body = "") {
       const { window } = new JSDOM(`<html><body>${body}</body></html>`);
@@ -183,24 +139,6 @@ Object.keys(selectors).forEach((variant) => {
           title: "A Selected GitHub Issue",
           type: "bug",
           url: "https://github.com/test-org/test-project/issues/12",
-        },
-      ]);
-    });
-
-    it("extracts tickets from project pages", async () => {
-      const result = await scan(url("projects/1"), doc(html.projectpage));
-      expect(result).toEqual([
-        {
-          id: "42",
-          title: "An Example Feature Ticket",
-          type: "feature",
-          url: "https://github.com/test-org/test-project/issues/42",
-        },
-        {
-          id: "43",
-          title: "An Example Bug Ticket",
-          type: "bug",
-          url: "https://github.com/test-org/test-project/issues/43",
         },
       ]);
     });

--- a/src/core/adapters/github.ts
+++ b/src/core/adapters/github.ts
@@ -18,9 +18,9 @@ import { hasRequiredDetails } from "./utils";
 export const selectors = {
   default: {
     issuesPage: ".js-check-all-container .js-issue-row.selected",
-    issuesPageLabel: ".labels .IssueLabel",
+    issuesPageLabel: ".lh-default .IssueLabel",
     issuePage: ".js-issues-results .gh-header-number",
-    issuePageLabel: '.js-issue-labels .sidebar-labels-style[title="bug"]',
+    issuePageLabel: '.js-issue-labels .IssueLabel[data-name="bug" i]',
   },
   legacy: {
     issuesPage: ".issues-listing .js-issue-row.selected",

--- a/src/core/adapters/github.ts
+++ b/src/core/adapters/github.ts
@@ -38,16 +38,21 @@ async function attempt(
   if ($has(select.issuesPage, doc)) {
     const issues = $all(select.issuesPage, doc);
 
-    const tickets = issues.map((issue) => {
+    const tickets = issues.reduce((acc, issue) => {
       const id = $value("input.js-issues-list-check", issue);
       const title = $text("a.js-navigation-open", issue);
+
+      if (!id || !title) return acc;
+
       const labels = $all(select.issuesPageLabel, issue);
       const type = labels.some((l) => /bug/i.test(`${l.textContent}`))
         ? "bug"
         : "feature";
 
-      return { id, title, type };
-    });
+      const ticket = { id, title, type };
+      acc.push(ticket);
+      return acc;
+    }, <TicketData[]>[]);
 
     return tickets;
   }
@@ -56,27 +61,11 @@ async function attempt(
   if ($has(select.issuePage, doc)) {
     const id = $text(".gh-header-number", doc)?.replace(/^#/, "");
     const title = $text(".js-issue-title", doc);
+
+    if (!id || !title) return [];
+
     const type = $has(select.issuePageLabel, doc) ? "bug" : "feature";
     const tickets = [{ id, title, type }];
-    return tickets;
-  }
-
-  // project page
-  if ($has(".project-columns .project-card", doc)) {
-    const openProjectCardSelector =
-      ".project-columns .project-card[data-card-state='[\"open\"]']";
-    const projectCards = $all(openProjectCardSelector, doc);
-
-    const tickets = projectCards.map((card) => {
-      const id = JSON.parse(card.dataset.cardTitle ?? "null").slice(-2, -1)[0];
-      const type = JSON.parse(card.dataset.cardLabel ?? "null").includes("bug")
-        ? "bug"
-        : "feature";
-      const title = $text("a.h5", card);
-
-      return { id, title, type };
-    });
-
     return tickets;
   }
 


### PR DESCRIPTION
This updates the GitHub adapter for the new Markup GitHub uses for labels on issues. With this change, issues labelled as "bug" should again result into a branch name like `bug/xyz/`.

On the side, this also removes the code for selecting issues on GitHub project pages. GitHub projects are entities on the user/organization now, not part of a repository. If we want to support them, it needs to be done differently. There's a follow up issue for that #403.
