### PR TITLE
feat: add support for plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Currently, we support:
 - [Jira](https://www.atlassian.com/software/jira)
 - [Linear](https://linear.app)
 - [Notion](https://www.notion.so/)
+- [Plane](https://plane.so/)
 - [Tara](https://app.tara.ai/)
 - [Trello](https://trello.com/)
 - [YouTrack](https://www.jetbrains.com/youtrack/)

--- a/src/core/adapters/plane.test.ts
+++ b/src/core/adapters/plane.test.ts
@@ -11,7 +11,7 @@ const pages = {
     url: new URL(
       "https://app.plane.so/my_team/projects/e9460bd9-2967-4c5e-8d95-24b053e6965d/issues/9210a612-338b-4620-a834-07a89a26bf65/",
     ),
-    document: "<title>FOO-1 Do something interesting</title><meta property='og:title' content='Plane | Simple, extensible, open-source project management tool.'>",
+    document: "<title>FOO-1 Do something interesting</title><meta property='og:url' content='https://app.plane.so/'>",
   },
 };
 

--- a/src/core/adapters/plane.test.ts
+++ b/src/core/adapters/plane.test.ts
@@ -26,7 +26,7 @@ describe("plane adapter", () => {
     expect(result).toEqual([]);
   });
 
-  it("extracts the ticket from the issue page", async () => {
+  it("extracts the ticket info from the issue page", async () => {
     const result = await scan(
       pages.issuePage.url,
       doc(pages.issuePage.document),

--- a/src/core/adapters/plane.test.ts
+++ b/src/core/adapters/plane.test.ts
@@ -11,13 +11,16 @@ const pages = {
     url: new URL(
       "https://app.plane.so/my_team/projects/e9460bd9-2967-4c5e-8d95-24b053e6965d/issues/9210a612-338b-4620-a834-07a89a26bf65/",
     ),
-    document: "<title>FOO-1 Do something interesting</title><meta property='og:url' content='https://app.plane.so/'>",
+    document:
+      "<title>FOO-1 Do something interesting</title><meta property='og:url' content='https://app.plane.so/'>",
   },
 };
 
 describe("plane adapter", () => {
   function doc(head = "") {
-    const { window } = new JSDOM(`<html><head>${head}</head><body></body></html>`);
+    const { window } = new JSDOM(
+      `<html><head>${head}</head><body></body></html>`,
+    );
     return window.document;
   }
 

--- a/src/core/adapters/plane.test.ts
+++ b/src/core/adapters/plane.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment node
+ */
+
+import { JSDOM } from "jsdom";
+
+import scan from "./plane";
+
+const pages = {
+  issuePage: {
+    url: new URL(
+      "https://app.plane.so/my_team/projects/e9460bd9-2967-4c5e-8d95-24b053e6965d/issues/9210a612-338b-4620-a834-07a89a26bf65/",
+    ),
+    document: "<title>FOO-1 Do something interesting</title><meta property='og:title' content='Plane | Simple, extensible, open-source project management tool.'>",
+  },
+};
+
+describe("plane adapter", () => {
+  function doc(head = "") {
+    const { window } = new JSDOM(`<html><head>${head}</head><body></body></html>`);
+    return window.document;
+  }
+
+  it("returns an empty array if it is on a different page", async () => {
+    const result = await scan(new URL("https://example.com"), doc());
+    expect(result).toEqual([]);
+  });
+
+  it("extracts the ticket from the issue page", async () => {
+    const result = await scan(
+      pages.issuePage.url,
+      doc(pages.issuePage.document),
+    );
+    expect(result).toEqual([
+      {
+        id: "FOO-1",
+        title: "Do something interesting",
+        type: "feature",
+        url: pages.issuePage.url.toString(),
+      },
+    ]);
+  });
+});

--- a/src/core/adapters/plane.ts
+++ b/src/core/adapters/plane.ts
@@ -11,11 +11,16 @@ import { $find, $text } from "./dom-helpers";
 import { hasRequiredDetails } from "./utils";
 
 async function scan(url: URL, document: Document): Promise<TicketData[]> {
-  const ogUrl = <HTMLMetaElement> $find("[property~='og:url'][content]", document);
+  const ogUrl = <HTMLMetaElement>(
+    $find("[property~='og:url'][content]", document)
+  );
   if (!ogUrl || ogUrl.content !== "https://app.plane.so/") return [];
 
-  let { issueType } = match("/:workspace/projects/:projectUuid/:issueType/:issueUuid/", url.pathname);
-  if (issueType == "issues") {
+  let { issueType } = match(
+    "/:workspace/projects/:projectUuid/:issueType/:issueUuid/",
+    url.pathname,
+  );
+  if (issueType === "issues") {
     issueType = "feature";
   }
 
@@ -24,12 +29,14 @@ async function scan(url: URL, document: Document): Promise<TicketData[]> {
   const id = extract && extract[1];
   const title = extract && extract[2];
 
-  const tickets = [{
-    id,
-    url: url.toString(),
-    title,
-    type: issueType,
-  }];
+  const tickets = [
+    {
+      id,
+      url: url.toString(),
+      title,
+      type: issueType,
+    },
+  ];
 
   return tickets.filter(hasRequiredDetails) as TicketData[];
 }

--- a/src/core/adapters/plane.ts
+++ b/src/core/adapters/plane.ts
@@ -1,0 +1,37 @@
+/**
+ * Plane adapter
+ *
+ * The adapter extracts ticket information from the markup.
+ */
+
+import { match } from "micro-match";
+
+import type { TicketData } from "../types";
+import { $text } from "./dom-helpers";
+
+async function scan(url: URL, document: Document): Promise<TicketData[]> {
+  const checkForPlane = document.querySelector("[property~='og:title'][content]");
+  if (!checkForPlane || !checkForPlane.content.startsWith("Plane")) return [];
+
+  let { issueType } = match("/:workspace/projects/:projectId/:issueType/:id/", url.pathname);
+  if (issueType == "issues") {
+    issueType = "feature";
+  }
+  const pageTitle = $text("title", document);
+  const extract = pageTitle && pageTitle.match(/([A-Z]+-\d+)\s(.+)/);
+  const id = extract && extract[1];
+  const title = extract && extract[2];
+
+  if (!id) return [];
+
+  const ticket = {
+    id,
+    url: url.toString(),
+    title,
+    type: issueType,
+  } as TicketData;
+
+  return [ticket];
+}
+
+export default scan;

--- a/src/core/adapters/plane.ts
+++ b/src/core/adapters/plane.ts
@@ -7,31 +7,31 @@
 import { match } from "micro-match";
 
 import type { TicketData } from "../types";
-import { $text } from "./dom-helpers";
+import { $find, $text } from "./dom-helpers";
+import { hasRequiredDetails } from "./utils";
 
 async function scan(url: URL, document: Document): Promise<TicketData[]> {
-  const checkForPlane = document.querySelector("[property~='og:title'][content]");
-  if (!checkForPlane || !checkForPlane.content.startsWith("Plane")) return [];
+  const ogUrl = <HTMLMetaElement> $find("[property~='og:url'][content]", document);
+  if (!ogUrl || ogUrl.content !== "https://app.plane.so/") return [];
 
-  let { issueType } = match("/:workspace/projects/:projectId/:issueType/:id/", url.pathname);
+  let { issueType } = match("/:workspace/projects/:projectUuid/:issueType/:issueUuid/", url.pathname);
   if (issueType == "issues") {
     issueType = "feature";
   }
+
   const pageTitle = $text("title", document);
   const extract = pageTitle && pageTitle.match(/([A-Z]+-\d+)\s(.+)/);
   const id = extract && extract[1];
   const title = extract && extract[2];
 
-  if (!id) return [];
-
-  const ticket = {
+  const tickets = [{
     id,
     url: url.toString(),
     title,
     type: issueType,
-  } as TicketData;
+  }];
 
-  return [ticket];
+  return tickets.filter(hasRequiredDetails) as TicketData[];
 }
 
 export default scan;

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -8,9 +8,9 @@ import JiraCloud from "./adapters/jira-cloud";
 import JiraServer from "./adapters/jira-server";
 import Linear from "./adapters/linear";
 import Notion from "./adapters/notion";
+import Plane from "./adapters/plane";
 import Tara from "./adapters/tara";
 import Trello from "./adapters/trello";
-import Plane from "./adapters/plane";
 import defaults from "./defaults";
 import type { Adapter } from "./types";
 

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -10,6 +10,7 @@ import Linear from "./adapters/linear";
 import Notion from "./adapters/notion";
 import Tara from "./adapters/tara";
 import Trello from "./adapters/trello";
+import Plane from "./adapters/plane";
 import defaults from "./defaults";
 import type { Adapter } from "./types";
 
@@ -49,6 +50,7 @@ const stdadapters: Adapter[] = [
   Tara,
   Trello,
   Clickup,
+  Plane,
 ];
 
 export { search, stdadapters };

--- a/src/popup/components/__snapshots__/no-tickets.test.tsx.snap
+++ b/src/popup/components/__snapshots__/no-tickets.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`no-tickets with no errors renders a hint 1`] = `
     <p>
       Tickety-Tick currently supports
       <br />
-      GitHub, GitLab, Jira, Trello, Notion, Tara and Linear.
+      GitHub, GitLab, Jira, Trello, Notion, Tara, Linear and Plane.
     </p>
     <h6>
       Missing anything or found a bug?

--- a/src/popup/components/no-tickets.tsx
+++ b/src/popup/components/no-tickets.tsx
@@ -19,7 +19,7 @@ function Hint() {
       <p>
         Tickety-Tick currently supports
         <br />
-        GitHub, GitLab, Jira, Trello, Notion, Tara and Linear.
+        GitHub, GitLab, Jira, Trello, Notion, Tara, Linear and Plane.
       </p>
       <h6>Missing anything or found a bug?</h6>
       <p className="pb-1">


### PR DESCRIPTION
This PR adds an adapter to extract issue information from (self-hosted) [Plane](https://plane.so) instances. It extracts information from the url and the title tag and works from the issue detail page.