### PR TITLE
[432] Firefox Jira adapter broken with manifest v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@types/webextension-polyfill": "^0.12.1",
     "bootstrap": "5.1.1",
     "copy-text-to-clipboard": "^3.0.1",
+    "headers-polyfill": "^4.0.3",
     "ky": "^0.28.5",
     "mdast-util-from-adf": "^2.1.1",
     "mdast-util-gfm": "^2.0.0",

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,3 +1,5 @@
+import "../polyfills";
+
 import browser from "webextension-polyfill";
 
 import stdsearch from "../core/search";

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,6 @@
+import { Headers as HeadersPolyfill } from "headers-polyfill";
+
+// NOTE: With manifest v3, Firefox does not have an up to date implementation of
+// the `Headers` class. This breaks our HTTP client based on `ky`.
+// Therefore we use a polyfill for this:
+globalThis.Headers = HeadersPolyfill;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6357,6 +6357,11 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+headers-polyfill@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-4.0.3.tgz#922a0155de30ecc1f785bcf04be77844ca95ad07"
+  integrity sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==
+
 history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"


### PR DESCRIPTION
Polyfill Headers for Firefox

There is an issue with Manifest v3 in Firefox, that the global Headers
class does not work anymore (it did in Manifest v2). Therefore we're
overriding the global window.Headers to use a polyfill.

Doing so, `ky` can do it's header merging thing and our HTTP client works 🎉.

Fixes #432
