### PR TITLE
[#443] Fix GitHub adapter broken after GitHub redesign

### DIFF
--- a/src/core/adapters/dom-helpers.ts
+++ b/src/core/adapters/dom-helpers.ts
@@ -4,26 +4,26 @@ export function trim(string: string | null) {
 
 // Finders
 
-export function $find(selector: string, context: HTMLDocument | HTMLElement) {
+export function $find(selector: string, context: Document | HTMLElement) {
   return context.querySelector<HTMLElement>(selector);
 }
 
-export function $all(selector: string, context: HTMLDocument | HTMLElement) {
+export function $all(selector: string, context: Document | HTMLElement) {
   return Array.from(context.querySelectorAll<HTMLElement>(selector));
 }
 
-export function $has(selector: string, context: HTMLDocument | HTMLElement) {
+export function $has(selector: string, context: Document | HTMLElement) {
   return $find(selector, context) !== null;
 }
 
 // Properties
 
-export function $text(selector: string, context: HTMLDocument | HTMLElement) {
+export function $text(selector: string, context: Document | HTMLElement) {
   const node = $find(selector, context);
   return node ? trim(node.textContent) : null;
 }
 
-export function $value(selector: string, context: HTMLDocument | HTMLElement) {
+export function $value(selector: string, context: Document | HTMLElement) {
   const node = $find(selector, context);
   return node ? trim(node.getAttribute("value")) : null;
 }

--- a/src/core/adapters/github.test.ts
+++ b/src/core/adapters/github.test.ts
@@ -9,6 +9,43 @@ import scan, { selectors } from "./github";
 const pages = {
   default: {
     issuepage: `
+      <div data-testid="issue-viewer-container">
+        <div data-component="TitleArea" data-size-variant="medium">
+          <h1 data-component="PH_Title" data-hidden="false">
+            <bdi class="markdown-title" data-testid="issue-title">A Random GitHub Issue</bdi>
+            <span>#12</span>
+          </h1>
+        </div>
+      </div>`,
+    bugpage: `
+      <div data-testid="issue-viewer-container">
+        <div aria-label="Header" role="region" data-testid="issue-header">
+          <div data-component="TitleArea" data-size-variant="medium">
+            <h1 data-component="PH_Title" data-hidden="false">
+              <bdi class="markdown-title" data-testid="issue-title">A Random GitHub Issue</bdi>
+              <span>#12</span>
+            </h1>
+          </div>
+        </div>
+        <div data-testid="issue-viewer-metadata-pane">
+          <div data-testid="sidebar-section">
+            <div data-testid="issue-type-container">
+              <div>
+                <a href="/bitcrowd/tickety-tick/issues?q=type:&quot;Bug&quot;">
+                  <span data-color="RED">
+                    <span>
+                      <span>Bug</span>
+                    </span>
+                  </span>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>`,
+  },
+  legacy: {
+    issuepage: `
       <div class="js-issues-results">
         <h1 class="gh-header-title">
           <span class="js-issue-title">A Random GitHub Issue</span>
@@ -24,68 +61,6 @@ const pages = {
         <div class="js-issue-labels">
           <a class="IssueLabel hx_IssueLabel" data-name="bug">bug</a>
         </div>
-      </div>`,
-    indexpage: `
-        <div class="js-check-all-container">
-          <div>
-            <div id="issue_12" class="js-issue-row selected">
-              <input type="checkbox" class="js-issues-list-check" name="issues[]" value="12">
-              <a href="/bitcrowd/tickety-tick/issues/12" class="h4 js-navigation-open">
-                A Selected GitHub Issue
-              </a>
-              <span class="lh-default">
-                <a href="#" class="IssueLabel">bug</a>
-              </span>
-            </div>
-            <div id="issue_11" class="js-issue-row">
-              <input type="checkbox" class="js-issues-list-check" name="issues[]" value="11">
-              <a href="/bitcrowd/tickety-tick/issues/11" class="h4 js-navigation-open">
-                A GitHub Issue
-              </a>
-            </div>
-          </div>
-        </div>`,
-  },
-  legacy: {
-    issuepage: `
-      <div class="issues-listing">
-        <h1 class="gh-header-title">
-          <span class="js-issue-title">A Random GitHub Issue</span>
-          <span class="gh-header-number">#12</span>
-        </h1>
-      </div>`,
-
-    bugpage: `
-      <div class="issues-listing">
-        <h1 class="gh-header-title">
-          <span class="js-issue-title">A Random GitHub Issue</span>
-          <span class="gh-header-number">#12</span>
-        </h1>
-        <div class="sidebar-labels">
-          <a class="label" title="bug">bug</a>
-        </div>
-      </div>`,
-
-    indexpage: `
-      <div class="issues-listing">
-        <ul>
-          <li id="issue_12" class="js-issue-row selected">
-            <input type="checkbox" class="js-issues-list-check" name="issues[]" value="12">
-            <a href="/bitcrowd/tickety-tick/issues/12" class="h4 js-navigation-open">
-              A Selected GitHub Issue
-            </a>
-            <span class="labels">
-              <a href="#" class="label">bug</a>
-            </span>
-          </li>
-          <li id="issue_11" class="js-issue-row">
-            <input type="checkbox" class="js-issues-list-check" name="issues[]" value="11">
-            <a href="/bitcrowd/tickety-tick/issues/11" class="h4 js-navigation-open">
-              A GitHub Issue
-            </a>
-            <span class="labels"></span>
-          </li>
-        </ul>
       </div>`,
   },
 };
@@ -119,24 +94,12 @@ Object.keys(selectors).forEach((variant) => {
       ]);
     });
 
-    it("recognizes issues labelled as bugs", async () => {
+    it("recognizes issue types", async () => {
       const result = await scan(url("issues/12"), doc(html.bugpage));
       expect(result).toEqual([
         {
           id: "12",
           title: "A Random GitHub Issue",
-          type: "bug",
-          url: "https://github.com/test-org/test-project/issues/12",
-        },
-      ]);
-    });
-
-    it("extracts tickets from issues index pages", async () => {
-      const result = await scan(url("issues"), doc(html.indexpage));
-      expect(result).toEqual([
-        {
-          id: "12",
-          title: "A Selected GitHub Issue",
           type: "bug",
           url: "https://github.com/test-org/test-project/issues/12",
         },


### PR DESCRIPTION
This updates the GitHub adapter to work with the redesigned issue pages.
As we do not know now GitHub Enterprise looks like for the majority of
users, we keep the previous logic for the "legacy" strategy of the
adapter.

To keep the change and the adapter simple, I dropped support selecting
issues on the issues page. Instead, we only support the issue show pages
now. On the long run, it may make sense to look into supporting GitHub
projects too.

The new GitHub adapter supports GitHub issue types and won't look for
the "bug" label any more.

Ticket: https://github.com/bitcrowd/tickety-tick/issues/443

Fixes: #443
