### PR TITLE
Add support for Polarion

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Currently, we support:
 - [Tara](https://app.tara.ai/)
 - [Trello](https://trello.com/)
 - [YouTrack](https://www.jetbrains.com/youtrack/)
+- [Polarion](https://polarion.plm.automation.siemens.com)
 
 Your ticket system is missing? Go ahead and implement an adapter for it! We are always happy about contributions and here to support you 👋.
 

--- a/src/core/adapters/polarion.test.ts
+++ b/src/core/adapters/polarion.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ */
+
+import { JSDOM } from "jsdom";
+
+import scan from "./polarion";
+
+const url = new URL(
+  "https://polarion.company-url.com/polarion/#/project/test_project/workitem?id=RC-654",
+);
+
+const htmlSnippet = `
+<div class="polarion-WorkItem-TitleSection" id="DOM_2870"></div>
+<div>
+  <table>
+    <tbody>
+      <tr>
+        <td class="polarion-WorkItem-Title">
+          <table>
+            <tbody>
+              <tr>
+                <td class="polarion-WorkitemTitleIcons">
+                  <span class="polarion-no-style-cleanup">
+                    <a target="_top" class="polarion-Hyperlink" href="#/project/test_project/workitem?id=RC-654">
+                      <span>
+                        <img src="/polarion/icons/group/task.png" class="polarion-Icons">
+                      </span>
+                      <span>RC-654</span> - <span>Update Sha.js</span>
+                    </a>
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <!-- type field preview as in real Polarion preview -->
+  <table>
+    <tbody>
+      <tr>
+        <td class="polarion-NameCell" id="LABEL_type">Type:</td>
+        <td class="polarion-SectionLayouterContentCell" id="FIELD_type">
+          <span class="polarion-JSEnumOption" title="Task">Task</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <!-- description preview -->
+  <div id="FIELD_description">
+    <div class="polarion-WorkItemPreview-DescriptionPreview">
+      <span class="polarion-TextField polarion-RichTextFieldValue">
+        Use new versions of sha.js to address security issues.
+      </span>
+    </div>
+  </div>
+
+</div>
+`;
+
+describe("polarion adapter", () => {
+  function doc(body = "") {
+    const { window } = new JSDOM(
+      `<html><head><title>Title</title></head><body>${body}</body></html>`,
+    );
+    return window.document;
+  }
+
+  it("returns an empty array when on a different page", async () => {
+    const result = await scan(new URL("https://example.com/"), doc("other"));
+    expect(result).toEqual([]);
+  });
+
+  it("extracts ticket from Polarion workitem page", async () => {
+    const result = await scan(url, doc(htmlSnippet));
+
+    expect(result).toEqual([
+      {
+        id: "RC-654",
+        title: "Update Sha.js",
+        type: "feature",
+        url: url.toString(),
+        description: "Use new versions of sha.js to address security issues.",
+      },
+    ]);
+  });
+
+  it("extracts ticket with type 'bug' when type field is 'Bug'", async () => {
+    const bugHtml = htmlSnippet.replace('title="Task">Task', 'title="Bug">Bug');
+    const result = await scan(url, doc(bugHtml));
+
+    expect(result[0].type).toBe("bug");
+  });
+});

--- a/src/core/adapters/polarion.ts
+++ b/src/core/adapters/polarion.ts
@@ -1,0 +1,42 @@
+/**
+ * Polarion adapter
+ *
+ * The adapter extracts ticket information from Polarion workitem using DOM
+ * selectors.
+ */
+
+import type { TicketData } from "../types";
+import { $text } from "./dom-helpers";
+
+async function scan(url: URL, document: Document): Promise<TicketData[]> {
+  const polarionTitle = $text(
+    ".polarion-WorkItem-Title a.polarion-Hyperlink",
+    document,
+  );
+  const type =
+    $text("#FIELD_type .polarion-JSEnumOption", document)
+      ?.toLowerCase()
+      .trim() === "bug"
+      ? "bug"
+      : "feature";
+  const description = $text("#FIELD_description .polarion-TextField", document);
+
+  if (!polarionTitle || !type || !description) return [];
+
+  // polarionTitle follows the pattern "RC-654 - Title"
+  const match = polarionTitle.match(/^([A-Z0-9]+-[0-9]+)\s*[-:]\s*(.+)$/);
+
+  if (!match || match.length !== 3) return [];
+
+  return [
+    {
+      id: match[1],
+      title: match[2].trim(),
+      description,
+      type: type.toLowerCase(),
+      url: url.toString(),
+    },
+  ];
+}
+
+export default scan;

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -9,6 +9,7 @@ import JiraServer from "./adapters/jira-server";
 import Linear from "./adapters/linear";
 import Notion from "./adapters/notion";
 import Plane from "./adapters/plane";
+import Polarion from "./adapters/polarion";
 import Tara from "./adapters/tara";
 import Trello from "./adapters/trello";
 import defaults from "./defaults";
@@ -51,6 +52,7 @@ const stdadapters: Adapter[] = [
   Trello,
   Clickup,
   Plane,
+  Polarion,
 ];
 
 export { search, stdadapters };

--- a/src/popup/components/__snapshots__/no-tickets.test.tsx.snap
+++ b/src/popup/components/__snapshots__/no-tickets.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`no-tickets with no errors renders a hint 1`] = `
     <p>
       Tickety-Tick currently supports
       <br />
-      GitHub, GitLab, Jira, Trello, Notion, Tara, Linear and Plane.
+      GitHub, GitLab, Jira, Trello, Notion, Tara, Linear, Plane and Polarion.
     </p>
     <h6>
       Missing anything or found a bug?

--- a/src/popup/components/no-tickets.tsx
+++ b/src/popup/components/no-tickets.tsx
@@ -19,7 +19,7 @@ function Hint() {
       <p>
         Tickety-Tick currently supports
         <br />
-        GitHub, GitLab, Jira, Trello, Notion, Tara, Linear and Plane.
+        GitHub, GitLab, Jira, Trello, Notion, Tara, Linear, Plane and Polarion.
       </p>
       <h6>Missing anything or found a bug?</h6>
       <p className="pb-1">


### PR DESCRIPTION
I currently have to use [Polarion](https://polarion.plm.automation.siemens.com) 🥲 and miss being able to use Tickety-Tick to generate branches and commit messages.

I opted to get all information from the DOM instead of relying on the URL. I've tested this on my company's Polarion instance.

Thank you for the awesome plugin 💚


